### PR TITLE
fix: add getHeaders and getBody in Request class

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -19,6 +19,8 @@ class Request
         const std::string& getMethod() const { return _method; }
         const std::string& getPath() const { return _path; }
         const std::string& getVersion() const { return _version; }
+        const std::map<std::string, std::string>& getHeaders() const { return _headers; }
+        const std::string& getBody() const { return _body; }
 
     private:
         std::string _method;


### PR DESCRIPTION
This pull request adds new accessor methods to the `Request` class in `include/Request.hpp`, allowing read-only access to the request headers and body. These changes will make it easier to retrieve header and body data from `Request` objects in other parts of the codebase.

New accessor methods:

* Added `getHeaders()` to return a const reference to the `_headers` map.
* Added `getBody()` to return a const reference to the `_body` string.