### PR TITLE
feat: implement CGI basics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp Response.cpp utils.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp Response.cpp utils.cpp CgiHandler.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiHandler.hpp
+++ b/include/CgiHandler.hpp
@@ -1,0 +1,14 @@
+#ifndef CGI_HANDLER_HPP
+# define CGI_HANDLER_HPP
+
+class CgiHandler
+{
+  public:
+    CgiHandler();
+    ~CgiHandler();
+
+    static void runCgi();
+};
+
+#endif
+

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -15,12 +15,14 @@ class Request
         void setVersion(const std::string& version) { _version = version; }
         void addHeader(const std::string& key, const std::string& value) { _headers[key] = value; }
         void setBody(const std::string& body) { _body = body; }
+        void setIsCgi() {_isCgi = true; }
 
         const std::string& getMethod() const { return _method; }
         const std::string& getPath() const { return _path; }
         const std::string& getVersion() const { return _version; }
         const std::map<std::string, std::string>& getHeaders() const { return _headers; }
         const std::string& getBody() const { return _body; }
+        int getIsCgi() const {return _isCgi; }
 
     private:
         std::string _method;
@@ -28,6 +30,7 @@ class Request
         std::string _version;
         std::map<std::string, std::string> _headers;
         std::string _body;
+        bool _isCgi;
 };
 
 #endif

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+#include <string>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <CgiHandler.hpp>
+
+CgiHandler::CgiHandler() {}
+CgiHandler::~CgiHandler() {}
+
+void CgiHandler::runCgi()
+{
+  int fd[2];
+  pid_t pid;
+  int status;
+
+  if (pipe(fd) < 0)
+    return;
+  pid = fork();
+  if (pid < 0)
+    return;
+  if (pid == 0)
+  {
+    dup2(fd[1], STDOUT_FILENO);
+    close(fd[1]);
+    close(fd[0]);
+    char *argv[] = { (char *)"/usr/bin/python3", (char *)"src/cgi-bin/test.py", NULL};
+    execve("/usr/bin/python3", argv, NULL);
+    _exit(1);
+  }
+  dup2(fd[0], STDIN_FILENO);
+  close(fd[1]);
+  ssize_t bytesRead;
+  std::string output;
+  char buffer[4096];
+
+  while ((bytesRead = read(fd[0], buffer, sizeof(buffer))))
+    output += buffer;
+  close(fd[0]);
+  waitpid(pid, &status, 0);
+  std::cout << output; // Testing CGI purposes
+  return;
+}

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -1,6 +1,7 @@
 #include "RequestHandler.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
+#include "CgiHandler.hpp"
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -45,6 +46,8 @@ Response RequestHandler::handleRequest(const Request& request)
     // Generate a response
     Response response;
 
+    if (request.getIsCgi())
+      CgiHandler::runCgi();
     if (request.getMethod() == "GET")
     {
             response = RequestHandler::handleStatic(request);

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -55,5 +55,6 @@ Request RequestParser::parse(const std::string &rawRequest) {
     parseHeader(ss, request);
   }
   // TODO: parse body if Content-Length is present
+  request.setIsCgi(); // For testing CGI
   return request;
 }

--- a/src/cgi-bin/test.py
+++ b/src/cgi-bin/test.py
@@ -1,0 +1,1 @@
+print("HELLO FROM PYTHON CGI!")


### PR DESCRIPTION
This pull request introduces initial support for CGI (Common Gateway Interface) handling in the web server. The main changes include the addition of a new `CgiHandler` class to execute CGI scripts, updates to the request flow to recognize and handle CGI requests, and a simple test CGI script. These changes lay the groundwork for integrating CGI script execution into the server's request handling pipeline.

**CGI Handling Integration:**

* Added a new `CgiHandler` class with a static method `runCgi()` that forks a process and executes a Python CGI script (`src/cgi-bin/test.py`), capturing and printing its output for testing purposes. (`include/CgiHandler.hpp` [[1]](diffhunk://#diff-0bb9b427bc2f12c3f34cf0057a9ccb5c51839b604fbd8d4d557447a9ab4c9429R1-R14) `src/CgiHandler.cpp` [[2]](diffhunk://#diff-e28d5e00d397bd6bdff9e8b1a46b38bc20112ba18139eca495da9e25ba734364R1-R42) `Makefile` [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L10-R10)
* Included `CgiHandler.hpp` in `RequestHandler.cpp` and updated the request handling logic to invoke `CgiHandler::runCgi()` if the request is marked as CGI. (`src/RequestHandler.cpp` [[1]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faR4) [[2]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faR49-R50)

**Request Object Enhancements:**

* Extended the `Request` class to include an `_isCgi` flag with setter (`setIsCgi`) and getter (`getIsCgi`) methods to indicate CGI requests. (`include/Request.hpp` [include/Request.hppR18-R33](diffhunk://#diff-0012e0273daabc35cd940e992d03a027de5e76698d37ed24cea77c6ec740defeR18-R33))
* Updated the request parsing logic to set the CGI flag on all requests for testing purposes. (`src/RequestParser.cpp` [src/RequestParser.cppR58](diffhunk://#diff-19f8429eec2b6269de118d43245e8c4eeb0eb7f2a1456c882395458106f2b198R58))

**Testing and Example Scripts:**

* Added a simple Python CGI script (`src/cgi-bin/test.py`) that outputs a test message, used by the CGI handler for demonstration. (`src/cgi-bin/test.py` [src/cgi-bin/test.pyR1](diffhunk://#diff-e855da5f36b4b63df73b1cff698008e3c5038e338dd8c57fe2770e982ec92723R1))