### PR TITLE
Cgi http env

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,61 @@ PATH_TRANSLATED
 
 ---
 
-### 12. Optional debug mode
+### 12. Test request `CONTENT_TYPE` and CGI response `Content-Type`
+
+Before running this test, temporarily change the CGI response content type in
+`www/cgi-bin/env.py`:
+
+```python
+print("Content-Type: text/test")
+```
+
+Then send a POST request with a different request content type:
+
+```bash
+curl -i -X POST \
+  -H "content-type: text/otherTest" \
+  -H "content-length: 11" \
+  -d "name=tigran" \
+  "http://localhost:8080/cgi-bin/env.py"
+```
+
+Expected response header:
+
+```http
+Content-Type: text/test
+```
+
+Expected important values inside the CGI output body:
+
+```txt
+CONTENT_LENGTH=11
+CONTENT_TYPE=text/otherTest
+```
+
+This test checks that:
+
+* the HTTP response `Content-Type` comes from the CGI script output header;
+* the CGI environment variable `CONTENT_TYPE` comes from the client request header;
+* request headers are handled case-insensitively;
+* `Content-Type` and `Content-Length` are not duplicated as `HTTP_CONTENT_TYPE` or `HTTP_CONTENT_LENGTH`.
+
+These two values are allowed to be different because they describe different message bodies:
+
+```txt
+Content-Type: text/test       -> response body returned by CGI
+CONTENT_TYPE=text/otherTest   -> request body received by CGI
+```
+
+After this test, restore `env.py` back to:
+
+```python
+print("Content-Type: text/plain")
+```
+
+---
+
+### 13. Optional debug mode
 
 During development, CGI environment variables can be printed on the server side before `execve()`.
 
@@ -367,6 +421,7 @@ Example `env.py` script used for testing:
 ```python
 #!/usr/bin/env python3
 import os
+import sys
 
 print("Content-Type: text/plain")
 print()
@@ -393,6 +448,15 @@ keys = [
 
 for key in keys:
     print(f"{key}={os.environ.get(key, '<missing>')}")
+
+http_keys = sorted(key for key in os.environ if key.startswith("HTTP_"))
+
+for key in http_keys:
+    print(f"{key}={os.environ.get(key, '<missing>')}")
+
+print()
+print("BODY:")
+print(sys.stdin.read())
 ```
 
 Make it executable:

--- a/include/CgiHandler.hpp
+++ b/include/CgiHandler.hpp
@@ -12,6 +12,11 @@ struct CgiStandardMetaVariables
 	CgiEnv values;
 };
 
+struct CgiHttpHeaderVariables
+{
+	CgiEnv values;
+};
+
 struct CgiResolvedPath
 {
 	bool isCgi;
@@ -30,6 +35,7 @@ struct CgiContext
 	std::string scriptPath;
 	std::string requestBody;
 	CgiStandardMetaVariables standard;
+	CgiHttpHeaderVariables httpHeaders;
 };
 
 class CgiHandler
@@ -42,6 +48,7 @@ public:
 
 private:
 	static void addEnv(CgiEnv &env, const std::string &key, const std::string &value);
+	static void mergeEnvironment(CgiEnv &dst, const CgiEnv &src);
 	static CgiEnv buildEnvironment(const CgiContext &context);
 	static std::vector<std::string> buildEnvironmentStrings(const CgiEnv &env);
 	static std::vector<char *> buildEnvironmentPointers(std::vector<std::string> &envStrings);

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -6,6 +6,8 @@
 #include <cerrno>
 #include <cstring>
 
+static void debugPrintEnv(const CgiEnv &env);
+
 CgiHandler::CgiHandler() {}
 CgiHandler::~CgiHandler() {}
 
@@ -14,11 +16,30 @@ void CgiHandler::addEnv(CgiEnv &env, const std::string &key, const std::string &
 	env[key] = value;
 }
 
+void CgiHandler::mergeEnvironment(CgiEnv &dst, const CgiEnv &src)
+{
+	CgiEnv::const_iterator it;
+
+	it = src.begin();
+	while (it != src.end())
+	{
+		dst[it->first] = it->second;
+		it++;
+	}
+}
+
 CgiEnv CgiHandler::buildEnvironment(const CgiContext &context)
 {
 	CgiEnv env;
+	CgiEnv envStandard;
+	CgiEnv envHttp;
 
-	env = context.standard.values;
+	envStandard = context.standard.values;
+	envHttp = context.httpHeaders.values;
+	debugPrintEnv(context.standard.values);
+	debugPrintEnv(context.httpHeaders.values);
+	mergeEnvironment(env, envStandard);
+	mergeEnvironment(env, envHttp);
 	return (env);
 }
 
@@ -91,7 +112,6 @@ std::string CgiHandler::runCgi(const CgiContext &context)
 	}
 
 	env = buildEnvironment(context);
-	debugPrintEnv(env);
 	envStrings = buildEnvironmentStrings(env);
 	envp = buildEnvironmentPointers(envStrings);
 

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -15,6 +15,9 @@
 
 #include <cctype>
 
+static bool headerNameEquals(const std::string &left, const std::string &right);
+static std::string trimHeaderValue(const std::string &value);
+
 RequestHandler::RequestHandler() {}
 
 RequestHandler::~RequestHandler() {}
@@ -42,44 +45,71 @@ Response RequestHandler::handleStatic(const Request &request)
     return res;
 }
 
+static void addCgiHeaderToResponse(Response &response,
+    const std::string &line)
+{
+    size_t      colon;
+    std::string name;
+    std::string value;
+
+    colon = line.find(':');
+    if (colon == std::string::npos)
+        return ;
+    name = line.substr(0, colon);
+    value = trimHeaderValue(line.substr(colon + 1));
+    if (name.empty())
+        return ;
+    response.addHeader(name, value);
+}
+
+static void addCgiHeadersToResponse(Response &response,
+    const std::string &headers)
+{
+    std::istringstream stream;
+    std::string        line;
+
+    stream.str(headers);
+    while (std::getline(stream, line))
+    {
+        if (!line.empty() && line[line.length() - 1] == '\r')
+            line.erase(line.length() - 1);
+        if (!line.empty())
+            addCgiHeaderToResponse(response, line);
+    }
+}
+
 static Response buildCgiResponse(const std::string &cgiOutput)
 {
-    Response response;
+    Response    response;
+    std::string separator;
+    size_t      bodyStart;
+    std::string cgiHeaders;
+    std::string cgiBody;
 
-    std::string separator = "\r\n\r\n";
-    size_t bodyStart = cgiOutput.find(separator);
-
+    separator = "\r\n\r\n";
+    bodyStart = cgiOutput.find(separator);
     if (bodyStart == std::string::npos)
     {
         separator = "\n\n";
         bodyStart = cgiOutput.find(separator);
     }
-
+    response.setStatusCode(200);
     if (bodyStart != std::string::npos)
     {
-        std::string cgiHeaders = cgiOutput.substr(0, bodyStart);
-        std::string cgiBody = cgiOutput.substr(bodyStart + separator.length());
-
-        response.setStatusCode(200);
+        cgiHeaders = cgiOutput.substr(0, bodyStart);
+        cgiBody = cgiOutput.substr(bodyStart + separator.length());
         response.setBody(cgiBody);
-
-        if (cgiHeaders.find("Content-Type:") != std::string::npos)
-            response.addHeader("Content-Type", "text/html");
-        else
-            response.addHeader("Content-Type", "text/plain");
+        addCgiHeadersToResponse(response, cgiHeaders);
     }
     else
     {
-        response.setStatusCode(200);
         response.setBody(cgiOutput);
         response.addHeader("Content-Type", "text/plain");
     }
-
     response.addHeader("Content-Length", intToString(response.getBody().length()));
     response.addHeader("Connection", "close");
-
     return (response);
-}
+}   
 
 static std::string getQueryString(const std::string &path)
 {
@@ -204,10 +234,14 @@ static std::string getHeaderValue(const Request &request, const std::string &nam
 {
     std::map<std::string, std::string>::const_iterator it;
 
-    it = request.getHeaders().find(name);
-    if (it != request.getHeaders().end())
-        return (trimHeaderValue(it->second));
-    return ("");
+	it = request.getHeaders().begin();
+	while (it != request.getHeaders().end())
+	{
+		if (headerNameEquals(it->first, name))
+			return (trimHeaderValue(it->second));
+		it++;
+	}
+	return ("");
 }
 
 static std::string getContentLength(const Request &request)

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <map>
 
+#include <cctype>
+
 RequestHandler::RequestHandler() {}
 
 RequestHandler::~RequestHandler() {}
@@ -241,6 +243,64 @@ static void addStandardCgiVariables(CgiContext &context, const Request &request,
     context.standard.values["SERVER_SOFTWARE"] = "webserv/1.0";
 }
 
+static bool headerNameEquals(const std::string &left, const std::string &right)
+{
+	size_t i;
+
+	if (left.length() != right.length())
+		return (false);
+	i = 0;
+	while (i < left.length())
+	{
+		if (std::tolower(static_cast<unsigned char>(left[i])) != std::tolower(static_cast<unsigned char>(right[i])))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+static bool isContentHeader(const std::string &name)
+{
+	if (headerNameEquals(name, "Content-Length"))
+		return (true);
+	if (headerNameEquals(name, "Content-Type"))
+		return (true);
+	return (false);
+}
+
+static std::string buildCgiHttpHeaderName(const std::string &name)
+{
+	std::string result;
+	size_t i;
+
+	result = "HTTP_";
+	i = 0;
+	while (i < name.length())
+	{
+		if (name[i] == '-')
+			result += '_';
+		else
+			result += static_cast<char>(std::toupper(static_cast<unsigned char>(name[i])));
+		i++;
+	}
+	return (result);
+}
+
+static void addHttpHeaderVariables(CgiContext &context, const Request &request)
+{
+	std::map<std::string, std::string>::const_iterator it;
+
+	it = request.getHeaders().begin();
+	while (it != request.getHeaders().end())
+	{
+		if (!isContentHeader(it->first))
+		{
+			context.httpHeaders.values[buildCgiHttpHeaderName(it->first)] = trimHeaderValue(it->second);
+		}
+		it++;
+	}
+}
+
 static CgiContext buildCgiContext(const Request &request, const ServerConfig &server, const std::string &remoteAddr, const CgiResolvedPath &cgiPath)
 {
     CgiContext context;
@@ -250,6 +310,7 @@ static CgiContext buildCgiContext(const Request &request, const ServerConfig &se
     context.requestBody = request.getBody();
     std::cout << "Request body for CGI:\n[" << context.requestBody << "]\n";
     addStandardCgiVariables(context, request, server, remoteAddr, cgiPath);
+    addHttpHeaderVariables(context, request);
     return (context);
 }
 

--- a/www/cgi-bin/env.py
+++ b/www/cgi-bin/env.py
@@ -28,6 +28,11 @@ keys = [
 for key in keys:
     print(f"{key}={os.environ.get(key, '<missing>')}")
 
+http_keys = sorted(key for key in os.environ if key.startswith("HTTP_"))
+
+for key in http_keys:
+    print(f"{key}={os.environ.get(key, '<missing>')}")
+
 print()
 print("BODY:")
 print(sys.stdin.read())

--- a/www/cgi-bin/env.py
+++ b/www/cgi-bin/env.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-print("Content-Type: text/plain")
+print("Content-Type: text/test")
 print()
 
 keys = [


### PR DESCRIPTION
This pull request implements a robust and standards-compliant separation of CGI environment variables for request headers and standard meta-variables, and updates the CGI header handling logic to ensure correct behavior for `Content-Type` and `Content-Length`. It also improves the test documentation and the example CGI script to help verify these behaviors.

**CGI environment and header handling improvements:**

* Introduced `CgiHttpHeaderVariables` in `CgiHandler.hpp` and updated `CgiContext` to separate standard CGI meta-variables from HTTP header variables, ensuring that only appropriate headers are mapped to `HTTP_*` environment variables and that `CONTENT_TYPE` and `CONTENT_LENGTH` are not duplicated. [[1]](diffhunk://#diff-0bb9b427bc2f12c3f34cf0057a9ccb5c51839b604fbd8d4d557447a9ab4c9429R15-R19) [[2]](diffhunk://#diff-0bb9b427bc2f12c3f34cf0057a9ccb5c51839b604fbd8d4d557447a9ab4c9429R38)
* Added logic to merge standard and HTTP header CGI variables when building the CGI environment, and refactored the environment build process to use this separation. [[1]](diffhunk://#diff-0bb9b427bc2f12c3f34cf0057a9ccb5c51839b604fbd8d4d557447a9ab4c9429R51) [[2]](diffhunk://#diff-e28d5e00d397bd6bdff9e8b1a46b38bc20112ba18139eca495da9e25ba734364R19-R42)
* Implemented case-insensitive header matching and ensured only non-content headers are mapped to `HTTP_*` variables, preventing duplication of `Content-Type` and `Content-Length`. [[1]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faL205-R243) [[2]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faR280-R337)
* Updated CGI response parsing to extract and set headers from CGI script output, allowing the CGI script to control the response `Content-Type` and other headers.

**Testing and documentation updates:**

* Added a new test to `README.md` to verify the separation between request `CONTENT_TYPE` and response `Content-Type`, and clarified the expected behaviors.
* Enhanced the example `env.py` CGI script to print all `HTTP_*` variables and the request body, aiding in debugging and testing of CGI environment variable handling. [[1]](diffhunk://#diff-9b4821c1addf9af187bd72418a3759929ac994cf7bd621c4e64d3d857f2f027eL5-R5) [[2]](diffhunk://#diff-9b4821c1addf9af187bd72418a3759929ac994cf7bd621c4e64d3d857f2f027eR31-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R424) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R451-R459)