### PR TITLE
Redirect base

### DIFF
--- a/src/ConfigValidator.cpp
+++ b/src/ConfigValidator.cpp
@@ -25,7 +25,13 @@ static bool isRedirectStatusCode(int code)
 
 static bool isValidRedirectTarget(const std::string &target)
 {
-    return (!target.empty() && target[0] == '/');
+    if (target.empty())
+        return (false);
+    if (target[0] != '/')
+        return (false);
+    if (target.length() > 1 && target[1] == '/')
+        return (false);
+    return (true);
 }
 
 void ConfigValidator::validate(const Config &config)

--- a/src/ConfigValidator.cpp
+++ b/src/ConfigValidator.cpp
@@ -23,6 +23,11 @@ static bool isRedirectStatusCode(int code)
     return (code == 301 || code == 302 || code == 303 || code == 307 || code == 308);
 }
 
+static bool isValidRedirectTarget(const std::string &target)
+{
+    return (!target.empty() && target[0] == '/');
+}
+
 void ConfigValidator::validate(const Config &config)
 {
 	if (config.servers.empty())
@@ -49,6 +54,8 @@ void ConfigValidator::validate(const Config &config)
 				throw configError("location " + route.path + " has upload_enable on but upload_store is missing");
 			if (route.hasReturn && !isRedirectStatusCode(route.returnCode))
     			throw configError("location " + route.path + " has invalid redirect status code");
+			if (route.hasReturn && !isValidRedirectTarget(route.returnPath))
+    			throw configError("location " + route.path + " has invalid redirect target");
 		}
 	}
 }

--- a/src/ConfigValidator.cpp
+++ b/src/ConfigValidator.cpp
@@ -18,6 +18,11 @@ static std::string toString(int value)
 	return (oss.str());
 }
 
+static bool isRedirectStatusCode(int code)
+{
+    return (code == 301 || code == 302 || code == 303 || code == 307 || code == 308);
+}
+
 void ConfigValidator::validate(const Config &config)
 {
 	if (config.servers.empty())
@@ -42,8 +47,8 @@ void ConfigValidator::validate(const Config &config)
 				throw configError("location " + route.path + " has no allowed methods");
 			if (route.uploadEnable && route.uploadStore.empty())
 				throw configError("location " + route.path + " has upload_enable on but upload_store is missing");
-			if (route.hasReturn && (route.returnCode < 100 || route.returnCode > 599))
-				throw configError("location " + route.path + " has invalid return status code");
+			if (route.hasReturn && !isRedirectStatusCode(route.returnCode))
+    			throw configError("location " + route.path + " has invalid redirect status code");
 		}
 	}
 }

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -496,12 +496,45 @@ Response RequestHandler::handleHttpDelete(const Request &request, const RouteCon
     return res;
 }
 
+static bool isRedirectStatusCode(int code)
+{
+    return (code == 301 || code == 302 || code == 303 || code == 307 || code == 308);
+}
+
+static Response buildRedirectResponse(const RouteConfig &route)
+{
+    Response response;
+    std::string body;
+
+    if (!isRedirectStatusCode(route.returnCode))
+        return (buildErrorResponse(500, "Internal Server Error"));
+
+    response.setStatusCode(route.returnCode);
+    response.addHeader("Location", route.returnPath);
+    response.addHeader("Content-Type", "text/html");
+    response.addHeader("Connection", "close");
+
+    body = "<html><body><h1>"
+        + intToString(route.returnCode)
+        + " Redirect</h1><p>Redirecting to "
+        + route.returnPath
+        + "</p></body></html>";
+
+    response.setBody(body);
+    response.addHeader("Content-Length", intToString(body.length()));
+
+    return (response);
+}
+
 Response RequestHandler::handleRequest(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr)
 {
     // Generate a response
     Response response;
 
     CgiResolvedPath cgiPath;
+
+    if (route.hasReturn)
+        return (buildRedirectResponse(route));
 
     cgiPath = resolveCgiPath(request, route);
     if (cgiPath.isCgi)

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -533,6 +533,7 @@ Response RequestHandler::handleRequest(const Request &request, const RouteConfig
 
     CgiResolvedPath cgiPath;
 
+    // TODO: Move redirect after route method validation when method enforcement is implemented.
     if (route.hasReturn)
         return (buildRedirectResponse(route));
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -17,6 +17,14 @@ std::string Response::getReasonPhrase() const
       return ("OK");
     case 301:
       return ("Moved Permanently");
+    case 302:
+      return ("Found");
+    case 303:
+      return ("See Other");
+    case 307:
+      return ("Temporary Redirect");
+    case 308:
+      return ("Permanent Redirect");
     case 400:
       return ("Bad Request");
     case 403:


### PR DESCRIPTION
This pull request enhances how HTTP redirects are validated and handled in the configuration and response logic. It introduces stricter validation for redirect status codes and targets, ensures proper redirect responses are constructed, and improves the mapping of status codes to reason phrases.

**Redirect validation and response improvements:**

* Added helper functions `isRedirectStatusCode` and `isValidRedirectTarget` in `ConfigValidator.cpp` to enforce that redirect status codes are valid (301, 302, 303, 307, 308) and that redirect targets are well-formed (must start with a single `/` and not be empty).
* Updated `ConfigValidator::validate` to throw errors if a redirect uses an invalid status code or an invalid target, improving configuration robustness.

**HTTP response handling enhancements:**

* Added `buildRedirectResponse` and integrated redirect handling in `RequestHandler.cpp`, ensuring that requests to routes configured with `return` generate proper HTTP redirect responses with appropriate headers and body.
* Extended `Response::getReasonPhrase` in `Response.cpp` to return correct reason phrases for all common redirect status codes (302, 303, 307, 308), improving HTTP standards compliance.