### PR TITLE
Redirect handler refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/RedirectHandler.hpp
+++ b/include/RedirectHandler.hpp
@@ -1,0 +1,19 @@
+#ifndef REDIRECTHANDLER_HPP
+#define REDIRECTHANDLER_HPP
+
+#include "Config.hpp"
+#include "Response.hpp"
+
+class RedirectHandler
+{
+public:
+    static Response handle(const RouteConfig &route);
+
+private:
+    RedirectHandler();
+    RedirectHandler(const RedirectHandler &other);
+    RedirectHandler &operator=(const RedirectHandler &other);
+    ~RedirectHandler();
+};
+
+#endif

--- a/src/RedirectHandler.cpp
+++ b/src/RedirectHandler.cpp
@@ -1,0 +1,50 @@
+#include "RedirectHandler.hpp"
+#include "ErrorResponseBuilder.hpp"
+#include "utils.hpp"
+
+#include <string>
+
+RedirectHandler::RedirectHandler() {}
+
+RedirectHandler::RedirectHandler(const RedirectHandler &other)
+{
+    (void)other;
+}
+
+RedirectHandler &RedirectHandler::operator=(const RedirectHandler &other)
+{
+    (void)other;
+    return (*this);
+}
+
+RedirectHandler::~RedirectHandler() {}
+
+static bool isRedirectStatusCode(int code)
+{
+    return (code == 301 || code == 302 || code == 303 || code == 307 || code == 308);
+}
+
+Response RedirectHandler::handle(const RouteConfig &route)
+{
+    Response response;
+    std::string body;
+
+    if (!isRedirectStatusCode(route.returnCode))
+        return (ErrorResponseBuilder::build(500, "Internal Server Error"));
+
+    response.setStatusCode(route.returnCode);
+    response.addHeader("Location", route.returnPath);
+    response.addHeader("Content-Type", "text/html");
+    response.addHeader("Connection", "close");
+
+    body = "<html><body><h1>"
+        + intToString(route.returnCode)
+        + " Redirect</h1><p>Redirecting to "
+        + route.returnPath
+        + "</p></body></html>";
+
+    response.setBody(body);
+    response.addHeader("Content-Length", intToString(body.length()));
+
+    return (response);
+}

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -1,5 +1,6 @@
 #include "ErrorResponseBuilder.hpp"
 #include "StaticFileHandler.hpp"
+#include "RedirectHandler.hpp"
 #include "RequestHandler.hpp"
 #include "CgiHandler.hpp"
 #include "Request.hpp"
@@ -462,36 +463,6 @@ Response RequestHandler::handleHttpDelete(const Request &request, const RouteCon
     return res;
 }
 
-static bool isRedirectStatusCode(int code)
-{
-    return (code == 301 || code == 302 || code == 303 || code == 307 || code == 308);
-}
-
-static Response buildRedirectResponse(const RouteConfig &route)
-{
-    Response response;
-    std::string body;
-
-    if (!isRedirectStatusCode(route.returnCode))
-        return (ErrorResponseBuilder::build(500, "Internal Server Error"));
-
-    response.setStatusCode(route.returnCode);
-    response.addHeader("Location", route.returnPath);
-    response.addHeader("Content-Type", "text/html");
-    response.addHeader("Connection", "close");
-
-    body = "<html><body><h1>"
-        + intToString(route.returnCode)
-        + " Redirect</h1><p>Redirecting to "
-        + route.returnPath
-        + "</p></body></html>";
-
-    response.setBody(body);
-    response.addHeader("Content-Length", intToString(body.length()));
-
-    return (response);
-}
-
 static bool hasHeader(const Response &response, const std::string &name)
 {
     std::map<std::string, std::string> headers;
@@ -509,7 +480,7 @@ Response RequestHandler::handleRequest(const Request &request, const RouteConfig
 
     // TODO: Move redirect after route method validation when method enforcement is implemented.
     if (route.hasReturn)
-        return (buildRedirectResponse(route));
+        return (RedirectHandler::handle(route));
 
     cgiPath = resolveCgiPath(request, route);
     if (cgiPath.isCgi)


### PR DESCRIPTION
This pull request introduces a dedicated `RedirectHandler` class to centralize and simplify HTTP redirect response handling. The main changes involve refactoring redirect logic from `RequestHandler.cpp` into the new handler, updating includes and build files, and removing redundant code.

**Redirect handling refactor:**

* Added a new `RedirectHandler` class with a static `handle` method for building redirect responses, encapsulating redirect logic previously duplicated in `RequestHandler.cpp` (`include/RedirectHandler.hpp`, `src/RedirectHandler.cpp`). [[1]](diffhunk://#diff-6cc564f074fff937eaf7cf05c1127a4f67d2a574be44275c9979151c391c8386R1-R19) [[2]](diffhunk://#diff-fed3b667d7542c0909c4925bceb5f1b9965c413ab5929db5d9fa44d60ebfe223R1-R50)
* Updated `RequestHandler.cpp` to use `RedirectHandler::handle` instead of local redirect response functions. This removes the now-redundant `isRedirectStatusCode` and `buildRedirectResponse` functions from `RequestHandler.cpp` [[1]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faR3) [[2]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faL465-L494) [[3]](diffhunk://#diff-91b4885355bc64a2cd99fbf3ff696d482547ddefc371f887b1febea79de049faL512-R483)

**Build system updates:**

* Added `RedirectHandler.cpp` to the `SRC_FILES` variable in the `Makefile` to ensure it's compiled and linked.