### PR TITLE
Partial write base

### DIFF
--- a/docs/partial-write-tests.md
+++ b/docs/partial-write-tests.md
@@ -1,0 +1,122 @@
+# Partial Write Handling Tests
+
+This document describes a small manual test set for verifying that the server correctly handles partial writes.
+
+## Goal
+
+Before this fix, the server could close the client connection after a single successful `send()` call, even if only part of the response had actually been sent.
+
+This caused large responses to be truncated.
+
+After the fix, each client keeps:
+
+* a response buffer;
+* the current write offset;
+* a response-ready state.
+
+The server continues sending the remaining data on later `POLLOUT` events and closes the connection only when the full response has been sent.
+
+---
+
+## Test 1 — Large static file
+
+Create a large static file:
+
+```bash
+dd if=/dev/urandom of=www/static/big.bin bs=1M count=20
+```
+
+Start the server:
+
+```bash
+make re
+./webserv configs/default.conf
+```
+
+Download the file:
+
+```bash
+curl -o /tmp/big.bin http://localhost:8080/static/big.bin
+```
+
+Compare file sizes:
+
+```bash
+stat -c%s www/static/big.bin
+stat -c%s /tmp/big.bin
+```
+
+Expected result:
+
+```txt
+20971520
+20971520
+```
+
+Verify that the files are identical:
+
+```bash
+cmp www/static/big.bin /tmp/big.bin
+echo $?
+```
+
+Expected result:
+
+```txt
+0
+```
+
+---
+
+## Test 2 — Slow client
+
+This test simulates a slow client by limiting the download speed.
+
+```bash
+rm -f /tmp/big.bin
+curl --limit-rate 100k -o /tmp/big.bin http://localhost:8080/static/big.bin
+```
+
+Verify the downloaded file:
+
+```bash
+cmp www/static/big.bin /tmp/big.bin
+echo $?
+```
+
+Expected result:
+
+```txt
+0
+```
+
+---
+
+## Expected behavior
+
+The server should:
+
+* send the full response body;
+* keep the connection open while data remains to be sent;
+* continue sending on later `POLLOUT` events;
+* close the connection only after the full response has been sent.
+
+---
+
+## Failure example before the fix
+
+Before the fix, the slow-client test could fail with:
+
+```txt
+curl: (18) transfer closed with X bytes remaining to read
+```
+
+This meant that the server closed the connection before sending the full response.
+
+---
+
+## Notes
+
+A successful test does not require the server to send the whole response in one `send()` call.
+
+The important point is that the final downloaded file must be identical to the original file.

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -32,6 +32,9 @@ class Client
     bool requestReady;
     ClientState state;
     size_t serverIndex;
+    std::string responseBuffer;
+    size_t bytesSent;
+    bool responseReady;
     //TODO: check if rawRequest is valid and finished before parsing
   private:
     std::string remoteAddr;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -3,5 +3,11 @@
 #include <unistd.h>
 #include "Client.hpp"
 
-Client::Client(int fd) : fd(fd), requestValid(false), requestReady(false), state(READING)  {}
-
+Client::Client(int fd)
+    : fd(fd),
+      requestValid(false),
+      requestReady(false),
+      state(READING),
+      serverIndex(0),
+      bytesSent(0),
+      responseReady(false) {}

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -137,25 +137,56 @@ static std::string getPathWithoutQuery(const std::string& path)
 
 int WebServ::SendToClient(Client& client)
 {
-	std::string cleanPath = getPathWithoutQuery(client.request.getPath());
-	const RouteConfig& route = findMatchingRoute(configs[client.serverIndex], cleanPath);
-	std::cout << "Matched route: " << route.path << std::endl;
-	Response response = RequestHandler::handleRequest(
-	    client.request, route, configs[client.serverIndex], client.getRemoteAddr());
-	std::cout << "Response to client:\n\n" << response.toString() << std::endl;
+    ssize_t bytesSent;
+    size_t remaining;
+    const char *data;
 
-	ssize_t bytesSent = send(
-	    client.fd, response.toString().c_str(), response.toString().size(), 0);
-	if (bytesSent == -1)
-	{
-		if (errno == EWOULDBLOCK || errno == EAGAIN)
-			return (0);
-		std::cout << "send: " << strerror(errno) << std::endl;
-		return (1);
-	}
-	if (bytesSent)
-		client.state = CLOSING_CONNECTION;
-	return (0);
+    if (!client.responseReady)
+    {
+        std::string cleanPath = getPathWithoutQuery(client.request.getPath());
+
+        const RouteConfig& route = findMatchingRoute(configs[client.serverIndex], cleanPath);
+
+        std::cout << "Matched route: " << route.path << std::endl;
+
+        Response response = RequestHandler::handleRequest(
+			client.request, route, configs[client.serverIndex], client.getRemoteAddr());
+
+        client.responseBuffer = response.toString();
+        client.bytesSent = 0;
+        client.responseReady = true;
+
+        std::cout << "Response to client:\n\n" << client.responseBuffer << std::endl;
+    }
+    if (client.bytesSent >= client.responseBuffer.size())
+    {
+        client.state = CLOSING_CONNECTION;
+        return (0);
+    }
+
+    remaining = client.responseBuffer.size() - client.bytesSent;
+    data = client.responseBuffer.c_str() + client.bytesSent;
+    bytesSent = send(client.fd, data, remaining, 0);
+
+    if (bytesSent == -1)
+    {
+        if (errno == EWOULDBLOCK || errno == EAGAIN)
+            return (0);
+        if (errno == EINTR)
+            return (0);
+        std::cout << "send: " << strerror(errno) << std::endl;
+        return (1);
+    }
+
+    if (bytesSent == 0)
+        return (0);
+
+    client.bytesSent += static_cast<size_t>(bytesSent);
+
+    if (client.bytesSent >= client.responseBuffer.size())
+        client.state = CLOSING_CONNECTION;
+
+    return (0);
 }
 
 int WebServ::initListeningSocket()


### PR DESCRIPTION
This pull request introduces proper handling of partial writes to client sockets, ensuring that large HTTP responses are sent completely even if the `send()` system call only transmits part of the data at a time. Previously, the server could close connections prematurely, resulting in truncated responses for large files or slow clients. The main changes include tracking response state and write progress per client, modifying the send logic to handle partial sends, and documenting manual test procedures.

**Partial write handling improvements:**

* The `Client` class now maintains a `responseBuffer`, `bytesSent`, and `responseReady` flag to track the response data, how much has been sent, and whether a response is ready to send (`include/Client.hpp`, `src/Client.cpp`). [[1]](diffhunk://#diff-e51bf9f83fe8e45333b20bd892f51a986ad580840527fc25cb55224675ed95eeR35-R37) [[2]](diffhunk://#diff-0070ad6232aacef7bac0064510add28e8fae5d8bc8e0475d2c17f38c3a5b836fL6-R13)
* The `WebServ::SendToClient` method has been refactored to:
  * Buffer the entire response before sending.
  * Attempt to send only the remaining bytes on each call.
  * Update the `bytesSent` counter and only close the connection after the full response is sent.
  * Properly handle non-fatal `send()` errors (e.g., `EWOULDBLOCK`, `EAGAIN`, `EINTR`).

**Documentation:**

* Added `docs/partial-write-tests.md`, which provides a manual test plan for verifying correct handling of large files and slow clients, and describes expected behavior and failure symptoms prior to this fix.