### PR TITLE
Cgi timeout

### DIFF
--- a/docs/non-blocking-cgi_tests.md
+++ b/docs/non-blocking-cgi_tests.md
@@ -448,6 +448,98 @@ HTTP/1.1 504 Gateway Timeout
 
 ---
 
+## CGI timeout
+
+These tests verify that a long-running CGI process is killed after the configured timeout and that the server continues working afterwards.
+
+Current timeout:
+
+```cpp
+static const int CGI_TIMEOUT_SECONDS = 10;
+```
+
+The server uses a dynamic `poll()` timeout through `getPollTimeoutMs()`, so `poll()` can block normally when no CGI is active and wakes up only when the nearest CGI timeout may need to be checked.
+
+### Short CGI should finish normally
+
+Create or use a CGI script that sleeps less than the timeout:
+
+```python
+#!/usr/bin/env python3
+
+import time
+
+time.sleep(2)
+
+print("Content-Type: text/plain")
+print()
+print("done")
+```
+
+Run:
+
+```bash
+curl -v http://127.0.0.1:8080/cgi-bin/sleep.py
+```
+
+Expected result:
+
+```txt
+HTTP/1.1 200 OK
+Content-Type: text/plain
+
+done
+```
+
+### Long CGI should timeout
+
+Change the same script to sleep longer than the timeout:
+
+```python
+#!/usr/bin/env python3
+
+import time
+
+time.sleep(20)
+
+print("Content-Type: text/plain")
+print()
+print("This should not be returned")
+```
+
+Run:
+
+```bash
+curl -v http://127.0.0.1:8080/cgi-bin/sleep.py
+```
+
+Expected result after about 10 seconds:
+
+```txt
+HTTP/1.1 504 Gateway Timeout
+```
+
+If a custom `504` page is configured, the body should be the custom error page.
+
+### Server should still work after timeout
+
+Immediately after the `504`, run:
+
+```bash
+curl -v http://127.0.0.1:8080/
+curl -v http://127.0.0.1:8080/static/
+```
+
+Expected result:
+
+```txt
+HTTP/1.1 200 OK
+```
+
+This confirms that CGI cleanup did not break the event loop.
+
+---
+
 ## Quick regression checklist
 
 ```bash

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -49,6 +49,7 @@ private:
 	void closeCgiFd(int fd);
 	void cleanupCgi(Client &client);
 	int checkCgiFinished(Client &client);
+	int checkCgiTimeouts(void);
 	void finishCgiResponse(Client &client);
 	void failCgiResponse(Client &client, int code, const std::string &message);
 	void resetCgiState(Client &client);

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -49,6 +49,7 @@ private:
 	void closeCgiFd(int fd);
 	void cleanupCgi(Client &client);
 	int checkCgiFinished(Client &client);
+	int getPollTimeoutMs(void) const;
 	int checkCgiTimeouts(void);
 	void finishCgiResponse(Client &client);
 	void failCgiResponse(Client &client, int code, const std::string &message);

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -24,7 +24,6 @@
 #include <sys/wait.h>
 
 static const int CGI_TIMEOUT_SECONDS = 5;
-static const int POLL_TIMEOUT_MS = 1000;
 
 WebServ::WebServ()
 {
@@ -632,6 +631,41 @@ int WebServ::checkCgiTimeouts(void)
 	return (0);
 }
 
+// No active CGI          → return -1
+// CGI already expired    → return 0
+// CGI available, N left  → return N * 1000
+int WebServ::getPollTimeoutMs(void) const
+{
+	std::map<int, Client>::const_iterator it;
+	time_t now;
+	int shortestTimeout;
+	int elapsed;
+	int remaining;
+
+	shortestTimeout = -1;
+	now = std::time(NULL);
+
+	it = clients.begin();
+	while (it != clients.end())
+	{
+		const Client &client = it->second;
+
+		if (client.cgiPid > 0 && client.cgiStartTime > 0)
+		{
+			elapsed = static_cast<int>(now - client.cgiStartTime);
+			remaining = CGI_TIMEOUT_SECONDS - elapsed;
+
+			if (remaining <= 0)
+				return (0);
+
+			if (shortestTimeout == -1 || remaining * 1000 < shortestTimeout)
+				shortestTimeout = remaining * 1000;
+		}
+		++it;
+	}
+	return (shortestTimeout);
+}
+
 void WebServ::resetCgiState(Client &client)
 {
 	client.cgiPid = -1;
@@ -766,7 +800,7 @@ int WebServ::run()
 
 	while (true)
 	{
-		int ready = poll(&this->pollFds[0], this->pollFds.size(), POLL_TIMEOUT_MS);
+		int ready = poll(&this->pollFds[0], this->pollFds.size(), getPollTimeoutMs());
 		if (ready < 0)
 		{
 			if (errno == EINTR)

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -23,6 +23,9 @@
 #include <signal.h>
 #include <sys/wait.h>
 
+static const int CGI_TIMEOUT_SECONDS = 5;
+static const int POLL_TIMEOUT_MS = 1000;
+
 WebServ::WebServ()
 {
 	std::cout << "WebServ created!\n";
@@ -605,6 +608,30 @@ int WebServ::checkCgiFinished(Client &client)
 	return (1);
 }
 
+int WebServ::checkCgiTimeouts(void)
+{
+	std::map<int, Client>::iterator it;
+	time_t now;
+
+	now = std::time(NULL);
+	it = clients.begin();
+	while (it != clients.end())
+	{
+		Client &client = it->second;
+
+		if (client.cgiPid > 0 && client.cgiStartTime > 0)
+		{
+			if (now - client.cgiStartTime >= CGI_TIMEOUT_SECONDS)
+			{
+				std::cout << "CGI timeout for client fd " << client.fd << std::endl;
+				failCgiResponse(client, 504, "Gateway Timeout");
+			}
+		}
+		++it;
+	}
+	return (0);
+}
+
 void WebServ::resetCgiState(Client &client)
 {
 	client.cgiPid = -1;
@@ -739,7 +766,7 @@ int WebServ::run()
 
 	while (true)
 	{
-		int ready = poll(&this->pollFds[0], this->pollFds.size(), -1);
+		int ready = poll(&this->pollFds[0], this->pollFds.size(), POLL_TIMEOUT_MS);
 		if (ready < 0)
 		{
 			if (errno == EINTR)
@@ -747,6 +774,13 @@ int WebServ::run()
 			std::cerr << "poll: " << strerror(errno) << std::endl;
 			return (1);
 		}
+		// Check CGI timeouts on each loop iteration
+		checkCgiTimeouts();
+
+		// No events, continue polling
+		if (ready == 0)
+			continue;
+
 		std::cout << "Sockets Ready - " << ready << "\n" << std::endl;
 
 		// PollFds loop


### PR DESCRIPTION
This pull request adds robust CGI timeout handling to the server, ensuring that long-running CGI scripts are properly terminated after a configurable timeout. It also updates the event loop to dynamically adjust its polling interval based on active CGI timeouts, and provides new documentation and tests for this behavior.

**CGI Timeout Handling:**

* Introduced a configurable CGI timeout (`CGI_TIMEOUT_SECONDS`) to limit how long a CGI script can run. If a script exceeds this duration, it is terminated and a `504 Gateway Timeout` response is returned. (`src/WebServ.cpp` [[1]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR26-R27) [[2]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR610-R668) [[3]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dL742-R817)
* Added the `checkCgiTimeouts()` method to iterate over clients and terminate any CGI processes that have exceeded the timeout. (`src/WebServ.cpp` [[1]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR610-R668) `include/WebServ.hpp` [[2]](diffhunk://#diff-cbaac149b8e958d07fc172d27917861e41377c210326346ca80b2b84eb1d04f9R52-R53)
* Implemented `getPollTimeoutMs()` to dynamically determine the appropriate timeout for the `poll()` call, based on the soonest CGI timeout. This ensures timely detection and cleanup of expired CGI processes. (`src/WebServ.cpp` [[1]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR610-R668) [[2]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dL742-R817) `include/WebServ.hpp` [[3]](diffhunk://#diff-cbaac149b8e958d07fc172d27917861e41377c210326346ca80b2b84eb1d04f9R52-R53)
* Modified the main event loop to use the dynamic poll timeout and to check for CGI timeouts on each iteration, improving server responsiveness and reliability. (`src/WebServ.cpp` [src/WebServ.cppL742-R817](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dL742-R817))

**Documentation and Testing:**

* Added a new section to the documentation (`docs/non-blocking-cgi_tests.md`) with detailed tests for CGI timeout behavior, including normal completion, timeout handling, and server stability after a timeout.