### PR TITLE
Fix header name normalization

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -13,7 +13,7 @@ class Request
         void setMethod(const std::string& method) { this->method = method; };
         void setPath(const std::string& path) { this->path = path; };
         void setVersion(const std::string& version) { this->version = version; };
-        void addHeader(const std::string& key, const std::string& value) { this->headers[key] = value; };
+        void addHeader(const std::string &key, const std::string &value);
         void setBody(const std::string& body) { this->body = body; };
         void setIsCgi() { this->isCgi = true; };
         void setValid() { this->valid = true; };

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 std::string intToString(int num);
+std::string	toLowerCase(const std::string &value);
 
 enum ResponseStatus
 {

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -1,5 +1,11 @@
 #include "Request.hpp"
+#include "utils.hpp"
 
 Request::Request() : isCgi(false)  {}
 
 Request::~Request() {}
+
+void Request::addHeader(const std::string &key, const std::string &value)
+{
+	headers[toLowerCase(key)] = value;
+}

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -1,4 +1,5 @@
 #include "RequestInspector.hpp"
+#include "utils.hpp"
 
 #include <string>
 #include <sstream>
@@ -81,11 +82,11 @@ static ContentLengthResult getContentLength(const std::string &headers, size_t &
 		if (colon == std::string::npos)
 			continue;
 
-		key = line.substr(0, colon);
+		key = toLowerCase(line.substr(0, colon));
 		value = line.substr(colon + 1);
 		trimLeft(value);
 
-		if (key == "Content-Length")
+		if (key == "content-length")
 		{
 			size_t current = 0;
 			// invalid CL (letters, signs...)

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -15,7 +15,7 @@ static bool getContentLength(const Request &request, size_t &contentLength)
     std::map<std::string, std::string>::const_iterator it;
     std::istringstream stream;
 
-    it = request.getHeaders().find("Content-Length");
+    it = request.getHeaders().find("content-length");
     if (it == request.getHeaders().end())
         return (false);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,24 @@
 #include <sstream>
 
-std::string intToString(int num) {
+std::string intToString(int num)
+{
   std::ostringstream oss;
   oss << num;
   return (oss.str());
+}
+
+std::string toLowerCase(const std::string &value)
+{
+  std::string result;
+  size_t index;
+
+  result = value;
+  index = 0;
+  while (index < result.length())
+  {
+    result[index] = static_cast<char>(
+        std::tolower(static_cast<unsigned char>(result[index])));
+    index++;
+  }
+  return (result);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,3 +1,6 @@
+#include "utils.hpp"
+
+#include <cctype>
 #include <sstream>
 
 std::string intToString(int num)


### PR DESCRIPTION
This pull request standardizes HTTP header key handling by ensuring all header keys are stored and compared in lowercase, improving case-insensitivity and consistency. It introduces a utility function for string lowercasing and updates relevant code to use this function when processing headers.

**Header key normalization:**

* Added a new utility function `toLowerCase` in `utils.cpp`/`utils.hpp` to convert strings to lowercase. [[1]](diffhunk://#diff-e5786da510ae17c4e629faa5583e79a5f37636702844b066763fba287aa44317R1-R27) [[2]](diffhunk://#diff-f91ec0996d4e82ab20ac7c71773bd8d68d667b1d1848a8e9835c0bb42ea13b42R7)
* Modified `Request::addHeader` in `Request.cpp`/`Request.hpp` to store header keys in lowercase using `toLowerCase`. [[1]](diffhunk://#diff-789ff71c9ed799fc669bb45934e7ec0d1127c71cc2bd97a367301eb807fef4efR2-R11) [[2]](diffhunk://#diff-0012e0273daabc35cd940e992d03a027de5e76698d37ed24cea77c6ec740defeL16-R16)
* Updated header lookups and processing in `RequestInspector.cpp` and `RequestParser.cpp` to use lowercase keys, ensuring consistent header access (e.g., `"content-length"` instead of `"Content-Length"`). [[1]](diffhunk://#diff-06e9deb5b289d755208679ef2579980f5ae60a16e3437e50c7f55c40c7855100L84-R89) [[2]](diffhunk://#diff-19f8429eec2b6269de118d43245e8c4eeb0eb7f2a1456c882395458106f2b198L18-R18)

**Code organization:**

* Included `utils.hpp` in relevant source files to provide access to the new utility function. [[1]](diffhunk://#diff-789ff71c9ed799fc669bb45934e7ec0d1127c71cc2bd97a367301eb807fef4efR2-R11) [[2]](diffhunk://#diff-06e9deb5b289d755208679ef2579980f5ae60a16e3437e50c7f55c40c7855100R2)