### PR TITLE
Refactor HTTP message utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/HttpMessageUtils.hpp
+++ b/include/HttpMessageUtils.hpp
@@ -1,0 +1,21 @@
+#ifndef HTTP_MESSAGE_UTILS_HPP
+# define HTTP_MESSAGE_UTILS_HPP
+
+# include <cstddef>
+# include <string>
+
+namespace HttpMessageUtils
+{
+	bool	findHeaderEnd(const std::string &rawMessage,
+					size_t &headerEnd,
+					size_t &bodyStart);
+	void	trimLeft(std::string &value);
+	void	trimRight(std::string &value);
+	void	trimHeaderValue(std::string &value);
+	bool	parseSize(const std::string &text, size_t &value);
+	bool	splitHeaderLine(const std::string &line,
+					std::string &key,
+					std::string &value);
+}
+
+#endif

--- a/include/HttpMessageUtils.hpp
+++ b/include/HttpMessageUtils.hpp
@@ -1,21 +1,17 @@
 #ifndef HTTP_MESSAGE_UTILS_HPP
-# define HTTP_MESSAGE_UTILS_HPP
+#define HTTP_MESSAGE_UTILS_HPP
 
-# include <cstddef>
-# include <string>
+#include <cstddef>
+#include <string>
 
 namespace HttpMessageUtils
 {
-	bool	findHeaderEnd(const std::string &rawMessage,
-					size_t &headerEnd,
-					size_t &bodyStart);
-	void	trimLeft(std::string &value);
-	void	trimRight(std::string &value);
-	void	trimHeaderValue(std::string &value);
-	bool	parseSize(const std::string &text, size_t &value);
-	bool	splitHeaderLine(const std::string &line,
-					std::string &key,
-					std::string &value);
+	bool findHeaderEnd(const std::string &rawMessage, size_t &headerEnd, size_t &bodyStart);
+	void trimLeft(std::string &value);
+	void trimRight(std::string &value);
+	void trimHeaderValue(std::string &value);
+	bool parseSize(const std::string &text, size_t &value);
+	bool splitHeaderLine(const std::string &line, std::string &key, std::string &value);
 }
 
 #endif

--- a/src/HttpMessageUtils.cpp
+++ b/src/HttpMessageUtils.cpp
@@ -2,9 +2,7 @@
 
 namespace HttpMessageUtils
 {
-	bool	findHeaderEnd(const std::string &rawMessage,
-					size_t &headerEnd,
-					size_t &bodyStart)
+	bool findHeaderEnd(const std::string &rawMessage, size_t &headerEnd, size_t &bodyStart)
 	{
 		headerEnd = rawMessage.find("\r\n\r\n");
 		if (headerEnd != std::string::npos)
@@ -23,33 +21,30 @@ namespace HttpMessageUtils
 		return (false);
 	}
 
-	void	trimLeft(std::string &value)
+	void trimLeft(std::string &value)
 	{
 		while (!value.empty() && (value[0] == ' ' || value[0] == '\t'))
 			value.erase(0, 1);
 	}
 
-	void	trimRight(std::string &value)
+	void trimRight(std::string &value)
 	{
-		while (!value.empty()
-			&& (value[value.length() - 1] == ' '
-				|| value[value.length() - 1] == '\t'
-				|| value[value.length() - 1] == '\r'))
+		while (!value.empty() && (value[value.length() - 1] == ' ' || value[value.length() - 1] == '\t' || value[value.length() - 1] == '\r'))
 		{
 			value.erase(value.length() - 1);
 		}
 	}
 
-	void	trimHeaderValue(std::string &value)
+	void trimHeaderValue(std::string &value)
 	{
 		trimLeft(value);
 		trimRight(value);
 	}
 
-	bool	parseSize(const std::string &text, size_t &value)
+	bool parseSize(const std::string &text, size_t &value)
 	{
-		const size_t	maxBeforeMul = static_cast<size_t>(-1) / 10;
-		size_t			i;
+		const size_t maxBeforeMul = static_cast<size_t>(-1) / 10;
+		size_t i;
 
 		if (text.empty())
 			return (false);
@@ -67,12 +62,10 @@ namespace HttpMessageUtils
 		return (true);
 	}
 
-	bool	splitHeaderLine(const std::string &line,
-					std::string &key,
-					std::string &value)
+	bool splitHeaderLine(const std::string &line, std::string &key, std::string &value)
 	{
-		std::string	cleanLine;
-		size_t		colon;
+		std::string cleanLine;
+		size_t colon;
 
 		cleanLine = line;
 		if (!cleanLine.empty() && cleanLine[cleanLine.length() - 1] == '\r')

--- a/src/HttpMessageUtils.cpp
+++ b/src/HttpMessageUtils.cpp
@@ -1,0 +1,87 @@
+#include "HttpMessageUtils.hpp"
+
+namespace HttpMessageUtils
+{
+	bool	findHeaderEnd(const std::string &rawMessage,
+					size_t &headerEnd,
+					size_t &bodyStart)
+	{
+		headerEnd = rawMessage.find("\r\n\r\n");
+		if (headerEnd != std::string::npos)
+		{
+			bodyStart = headerEnd + 4;
+			return (true);
+		}
+		headerEnd = rawMessage.find("\n\n");
+		if (headerEnd != std::string::npos)
+		{
+			bodyStart = headerEnd + 2;
+			return (true);
+		}
+		headerEnd = std::string::npos;
+		bodyStart = std::string::npos;
+		return (false);
+	}
+
+	void	trimLeft(std::string &value)
+	{
+		while (!value.empty() && (value[0] == ' ' || value[0] == '\t'))
+			value.erase(0, 1);
+	}
+
+	void	trimRight(std::string &value)
+	{
+		while (!value.empty()
+			&& (value[value.length() - 1] == ' '
+				|| value[value.length() - 1] == '\t'
+				|| value[value.length() - 1] == '\r'))
+		{
+			value.erase(value.length() - 1);
+		}
+	}
+
+	void	trimHeaderValue(std::string &value)
+	{
+		trimLeft(value);
+		trimRight(value);
+	}
+
+	bool	parseSize(const std::string &text, size_t &value)
+	{
+		const size_t	maxBeforeMul = static_cast<size_t>(-1) / 10;
+		size_t			i;
+
+		if (text.empty())
+			return (false);
+		value = 0;
+		i = 0;
+		while (i < text.length())
+		{
+			if (text[i] < '0' || text[i] > '9')
+				return (false);
+			if (value > maxBeforeMul)
+				return (false);
+			value = value * 10 + (text[i] - '0');
+			++i;
+		}
+		return (true);
+	}
+
+	bool	splitHeaderLine(const std::string &line,
+					std::string &key,
+					std::string &value)
+	{
+		std::string	cleanLine;
+		size_t		colon;
+
+		cleanLine = line;
+		if (!cleanLine.empty() && cleanLine[cleanLine.length() - 1] == '\r')
+			cleanLine.erase(cleanLine.length() - 1);
+		colon = cleanLine.find(':');
+		if (colon == std::string::npos)
+			return (false);
+		key = cleanLine.substr(0, colon);
+		value = cleanLine.substr(colon + 1);
+		return (true);
+	}
+}

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -1,5 +1,6 @@
 #include "RequestInspector.hpp"
 #include "ChunkedDecoder.hpp"
+#include "HttpMessageUtils.hpp"
 #include "utils.hpp"
 
 #include <string>
@@ -8,53 +9,6 @@
 const std::size_t MAX_HEADERS_SIZE = 32768;
 const std::size_t MAX_REQUEST_LINE_SIZE = 8192;
 // const std::size_t MAX_HEADER_FIELD_SIZE = 8192;
-
-static size_t findHeaderEnd(const std::string &rawRequest, size_t &bodyStart)
-{
-	size_t headerEnd;
-
-	headerEnd = rawRequest.find("\r\n\r\n");
-	if (headerEnd != std::string::npos)
-	{
-		bodyStart = headerEnd + 4;
-		return (headerEnd);
-	}
-
-	headerEnd = rawRequest.find("\n\n");
-	if (headerEnd != std::string::npos)
-	{
-		bodyStart = headerEnd + 2;
-		return (headerEnd);
-	}
-
-	bodyStart = std::string::npos;
-	return (std::string::npos);
-}
-
-static void trimLeft(std::string &value)
-{
-	while (!value.empty() && (value[0] == ' ' || value[0] == '\t'))
-		value.erase(0, 1);
-}
-
-static bool parseSize(const std::string &text, size_t &value)
-{
-	const size_t maxBeforeMul = static_cast<size_t>(-1) / 10;
-
-	if (text.empty())
-		return (false);
-
-	value = 0;
-	for (size_t i = 0; i < text.length(); ++i)
-	{
-		if (text[i] < '0' || text[i] > '9')
-			return (false);
-		if (value > maxBeforeMul)
-			return (false);
-		value = value * 10 + (text[i] - '0');
-	}
-	return (true);
-}
 
 enum ContentLengthResult
 {
@@ -69,29 +23,22 @@ static ContentLengthResult getContentLength(const std::string &headers, size_t &
 	std::string line;
 	std::string key;
 	std::string value;
-	size_t colon;
 	bool found = false;
 	size_t parsed = 0;
 
 	stream.str(headers);
 	while (std::getline(stream, line))
 	{
-		if (!line.empty() && line[line.length() - 1] == '\r')
-			line.erase(line.length() - 1);
-
-		colon = line.find(':');
-		if (colon == std::string::npos)
+		if (!HttpMessageUtils::splitHeaderLine(line, key, value))
 			continue;
-
-		key = toLowerCase(line.substr(0, colon));
-		value = line.substr(colon + 1);
-		trimLeft(value);
+		key = toLowerCase(key);
+		HttpMessageUtils::trimLeft(value);
 
 		if (key == "content-length")
 		{
 			size_t current = 0;
 			// invalid CL (letters, signs...)
-			if (!parseSize(value, current))
+			if (!HttpMessageUtils::parseSize(value, current))
 				return (CL_INVALID);
 			// conflicting CLs
 			if (found && current != parsed)
@@ -114,16 +61,6 @@ enum TransferEncodingResult
 	TE_INVALID
 };
 
-static void trimRight(std::string &value)
-{
-	while (!value.empty()
-		&& (value[value.length() - 1] == ' '
-			|| value[value.length() - 1] == '\t'))
-	{
-		value.erase(value.length() - 1);
-	}
-}
-
 static TransferEncodingResult getTransferEncoding(
 	const std::string &headers)
 {
@@ -131,7 +68,6 @@ static TransferEncodingResult getTransferEncoding(
 	std::string line;
 	std::string key;
 	std::string value;
-	size_t colon;
 	bool found;
 
 	stream.str(headers);
@@ -139,18 +75,10 @@ static TransferEncodingResult getTransferEncoding(
 
 	while (std::getline(stream, line))
 	{
-		if (!line.empty() && line[line.length() - 1] == '\r')
-			line.erase(line.length() - 1);
-
-		colon = line.find(':');
-		if (colon == std::string::npos)
+		if (!HttpMessageUtils::splitHeaderLine(line, key, value))
 			continue;
-
-		key = toLowerCase(line.substr(0, colon));
-		value = line.substr(colon + 1);
-
-		trimLeft(value);
-		trimRight(value);
+		key = toLowerCase(key);
+		HttpMessageUtils::trimHeaderValue(value);
 
 		if (key != "transfer-encoding")
 			continue;
@@ -268,8 +196,7 @@ InspectRequestStatus RequestInspector::inspectRequest(const std::string &rawRequ
 	if (this->status != COMPLETED)
 		return (this->status);
 
-	headerEnd = findHeaderEnd(rawRequest, bodyStart);
-	if (headerEnd == std::string::npos)
+	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
 	{
 		this->status = NEED_MORE_DATA;
 		return (this->status);

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -1,5 +1,6 @@
 #include "RequestParser.hpp"
 #include "ChunkedDecoder.hpp"
+#include "HttpMessageUtils.hpp"
 #include "Request.hpp"
 #include "utils.hpp"
 #include <sstream>
@@ -29,23 +30,6 @@ static bool getContentLength(const Request &request, size_t &contentLength)
     return (true);
 }
 
-static void trimHeaderValue(std::string &value)
-{
-	while (!value.empty()
-		&& (value[0] == ' ' || value[0] == '\t'))
-	{
-		value.erase(0, 1);
-	}
-
-	while (!value.empty()
-		&& (value[value.length() - 1] == ' '
-			|| value[value.length() - 1] == '\t'
-			|| value[value.length() - 1] == '\r'))
-	{
-		value.erase(value.length() - 1);
-	}
-}
-
 static bool isChunkedRequest(const Request &request)
 {
 	std::map<std::string, std::string>::const_iterator it;
@@ -57,7 +41,7 @@ static bool isChunkedRequest(const Request &request)
 		return (false);
 
 	value = it->second;
-	trimHeaderValue(value);
+	HttpMessageUtils::trimHeaderValue(value);
 	value = toLowerCase(value);
 
 	return (value == "chunked");
@@ -93,20 +77,11 @@ static void parseHeader(std::string &header, Request &request)
 {
     std::string key;
     std::string value;
-    size_t colonIndex;
 
-    if (!header.empty() && header[header.length() - 1] == '\r')
-        header.erase(header.length() - 1);
-
-    colonIndex = header.find(":");
-    if (colonIndex == std::string::npos)
+    if (!HttpMessageUtils::splitHeaderLine(header, key, value))
         return;
 
-    key = header.substr(0, colonIndex);
-    value = header.substr(colonIndex + 1);
-
-    while (!value.empty() && (value[0] == ' ' || value[0] == '\t'))
-        value.erase(0, 1);
+    HttpMessageUtils::trimLeft(value);
 
     request.addHeader(key, value);
 }
@@ -115,7 +90,6 @@ int RequestParser::parse(const std::string &rawRequest, Request &req)
 {
     size_t headerEnd;
     size_t bodyStart;
-    size_t separatorLength;
     std::string headerPart;
     std::string body;
     std::string requestLine;
@@ -126,19 +100,9 @@ int RequestParser::parse(const std::string &rawRequest, Request &req)
     if (rawRequest.empty())
         return (1);
 
-    headerEnd = rawRequest.find("\r\n\r\n");
-    separatorLength = 4;
-
-    if (headerEnd == std::string::npos)
-    {
-        headerEnd = rawRequest.find("\n\n");
-        separatorLength = 2;
-    }
-
-    if (headerEnd == std::string::npos)
+    if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
         return (1);
 
-    bodyStart = headerEnd + separatorLength;
     headerPart = rawRequest.substr(0, headerEnd);
 
     headerStream.str(headerPart);


### PR DESCRIPTION
## Summary

This PR extracts duplicated low-level HTTP message parsing helpers into a new `HttpMessageUtils` module.

## Changes

- Add `include/HttpMessageUtils.hpp`
- Add `src/HttpMessageUtils.cpp`
- Move shared header-boundary detection into `HttpMessageUtils::findHeaderEnd`
- Move shared header value trimming helpers
- Move strict numeric size parsing helper used by `RequestInspector`
- Move header line splitting helper
- Update `RequestInspector` to use the shared helpers
- Update `RequestParser` to use the shared helpers
- Add `HttpMessageUtils.cpp` to the Makefile

## Constraints

- Does not change `RequestParser::parse` public API
- Does not change `RequestInspector::inspectRequest` public API
- Does not change request lifecycle in `WebServ::run`
- Does not change chunked decoding behavior
- Does not fix unrelated known issues

## Validation checklist

- [ ] `make fclean && make`
- [ ] `make` does not relink unnecessarily
- [ ] Regression baseline has no new differences
- [ ] Known failures remain unchanged
- [ ] No new failures are introduced
