### PR TITLE
Refactor request inspection metadata

### DIFF
--- a/include/RequestInspector.hpp
+++ b/include/RequestInspector.hpp
@@ -2,6 +2,7 @@
 #define REQUEST_INSPECTOR_HPP
 
 #include "RequestLine.hpp"
+#include <cstddef>
 #include <string>
 
 enum InspectRequestStatus
@@ -17,13 +18,27 @@ enum InspectRequestStatus
 	INVALID
 };
 
+struct RequestInspection
+{
+	InspectRequestStatus status;
+	size_t headerEnd;
+	size_t bodyStart;
+	size_t messageEnd;
+	bool isChunked;
+	bool hasContentLength;
+	size_t contentLength;
+	RequestLine requestLine;
+
+	RequestInspection();
+};
+
 class RequestInspector
 {
 	public:
 		RequestInspector() : status(EMPTY), requestLineValid(false) {};
 		~RequestInspector() {};
 
-		InspectRequestStatus inspectRequest(const std::string &rawRequest, size_t maxBodySize);
+		RequestInspection inspectRequest(const std::string &rawRequest, size_t maxBodySize);
 		InspectRequestStatus status;
 
 	private:

--- a/include/RequestParser.hpp
+++ b/include/RequestParser.hpp
@@ -1,5 +1,5 @@
 #ifndef REQUESTPARSER_HPP
-# define REQUESTPARSER_HPP
+#define REQUESTPARSER_HPP
 
 #include <string>
 #include "Request.hpp"
@@ -7,12 +7,10 @@
 
 class RequestParser
 {
-  public:
-        RequestParser() {};
-        int parse(const std::string& rawRequest, Request& req, const RequestInspection &inspection);
-        InspectRequestStatus status;
-
-  private: 
+	public:
+		RequestParser() {};
+		int parse(const std::string &rawRequest, Request &req, const RequestInspection &inspection);
+		InspectRequestStatus status;
 };
 
 #endif

--- a/include/RequestParser.hpp
+++ b/include/RequestParser.hpp
@@ -9,7 +9,7 @@ class RequestParser
 {
   public:
         RequestParser() {};
-        int parse(const std::string& rawRequest, Request& req);
+        int parse(const std::string& rawRequest, Request& req, const RequestInspection &inspection);
         InspectRequestStatus status;
 
   private: 

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -15,6 +15,25 @@ enum ContentLengthResult
 	CL_INVALID
 };
 
+RequestInspection::RequestInspection()
+	: status(EMPTY),
+	  headerEnd(std::string::npos),
+	  bodyStart(std::string::npos),
+	  messageEnd(std::string::npos),
+	  isChunked(false),
+	  hasContentLength(false),
+	  contentLength(0),
+	  requestLine()
+{}
+
+static RequestInspection finishInspection(RequestInspector &inspector,
+	RequestInspection &inspection, InspectRequestStatus status)
+{
+	inspection.status = status;
+	inspector.status = status;
+	return (inspection);
+}
+
 static ContentLengthResult getContentLength(const std::string &headers, size_t &contentLength)
 {
 	std::istringstream stream;
@@ -122,129 +141,231 @@ void RequestInspector::inspectRequestLine(const std::string &requestLine, Reques
 	this->status = COMPLETED;
 }
 
-InspectRequestStatus RequestInspector::inspectRequest(const std::string &rawRequest, size_t maxBodySize)
-{
-	std::string requestLine;
-	std::stringstream ss;
-	size_t headerEnd;
-	size_t bodyStart;
-	size_t contentLength;
-	size_t currentBodySize;
-	std::string headers;
-	RequestLine parsedLine;
+// InspectRequestStatus RequestInspector::inspectRequest(const std::string &rawRequest, size_t maxBodySize)
+// {
+// 	std::string requestLine;
+// 	std::stringstream ss;
+// 	size_t headerEnd;
+// 	size_t bodyStart;
+// 	size_t contentLength;
+// 	size_t currentBodySize;
+// 	std::string headers;
+// 	RequestLine parsedLine;
 
-	std::string version;
-	TransferEncodingResult teResult;
-	ChunkedDecodeStatus chunkedStatus;
-	size_t messageEnd;
+// 	std::string version;
+// 	TransferEncodingResult teResult;
+// 	ChunkedDecodeStatus chunkedStatus;
+// 	size_t messageEnd;
+
+// 	if (rawRequest.empty())
+// 	{
+// 		this->status = NEED_MORE_DATA;
+// 		return (this->status);
+// 	}
+
+// 	ss << rawRequest;
+// 	if (!std::getline(ss, requestLine))
+// 	{
+// 		this->status = NEED_MORE_DATA;
+// 		return (this->status);
+// 	}
+
+// 	inspectRequestLine(requestLine, parsedLine);
+// 	if (this->status != COMPLETED)
+// 		return (this->status);
+
+// 	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
+// 	{
+// 		this->status = NEED_MORE_DATA;
+// 		return (this->status);
+// 	}
+
+// 	if (headerEnd > MAX_HEADERS_SIZE)
+// 	{
+// 		this->status = HEADER_TOO_LARGE;
+// 		return (this->status);
+// 	}
+
+// 	headers = rawRequest.substr(0, headerEnd);
+// 	contentLength = 0;
+
+// 	ContentLengthResult clResult;
+// 	clResult = getContentLength(headers, contentLength);
+
+// 	teResult = getTransferEncoding(headers);
+// 	version = parsedLine.getVersion();
+
+// 	if (clResult == CL_INVALID)
+// 	{
+// 		this->status = BAD_REQUEST;
+// 		return (this->status);
+// 	}
+// 	if (teResult == TE_INVALID)
+// 	{
+// 		this->status = BAD_REQUEST;
+// 		return (this->status);
+// 	}
+// 	if (teResult == TE_UNSUPPORTED)
+// 	{
+// 		this->status = NOT_IMPLEMENTED;
+// 		return (this->status);
+// 	}
+// 	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
+// 	{
+// 		this->status = BAD_REQUEST;
+// 		return (this->status);
+// 	}
+// 	if (teResult == TE_CHUNKED && clResult == CL_VALID)
+// 	{
+// 		this->status = BAD_REQUEST;
+// 		return (this->status);
+// 	}
+// 	if (teResult == TE_CHUNKED)
+// 	{
+// 		chunkedStatus = ChunkedDecoder::inspect(
+// 			rawRequest,
+// 			bodyStart,
+// 			maxBodySize,
+// 			messageEnd);
+// 		if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
+// 		{
+// 			this->status = NEED_MORE_DATA;
+// 			return (this->status);
+// 		}
+// 		if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
+// 		{
+// 			this->status = REQUEST_TOO_LARGE;
+// 			return (this->status);
+// 		}
+// 		if (chunkedStatus == CHUNKED_BAD_REQUEST)
+// 		{
+// 			this->status = BAD_REQUEST;
+// 			return (this->status);
+// 		}
+
+// 		this->status = COMPLETED;
+// 		return (this->status);
+// 	}
+
+// 	if (clResult == CL_VALID)
+// 	{
+// 		if (contentLength > maxBodySize)
+// 		{
+// 			this->status = REQUEST_TOO_LARGE;
+// 			return (this->status);
+// 		}
+
+// 		currentBodySize = rawRequest.length() - bodyStart;
+
+// 		if (currentBodySize < contentLength)
+// 		{
+// 			this->status = NEED_MORE_DATA;
+// 			return (this->status);
+// 		}
+// 	}
+
+// 	this->status = COMPLETED;
+// 	return (this->status);
+// }
+
+RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest,
+	size_t maxBodySize)
+{
+	RequestInspection		inspection;
+	std::string				requestLine;
+	std::stringstream		ss;
+	size_t					contentLength;
+	size_t					currentBodySize;
+	std::string				headers;
+	std::string				version;
+	TransferEncodingResult	teResult;
+	ChunkedDecodeStatus		chunkedStatus;
+	ContentLengthResult		clResult;
 
 	if (rawRequest.empty())
-	{
-		this->status = NEED_MORE_DATA;
-		return (this->status);
-	}
+		return (finishInspection(*this, inspection, NEED_MORE_DATA));
 
 	ss << rawRequest;
 	if (!std::getline(ss, requestLine))
-	{
-		this->status = NEED_MORE_DATA;
-		return (this->status);
-	}
+		return (finishInspection(*this, inspection, NEED_MORE_DATA));
 
-	inspectRequestLine(requestLine, parsedLine);
+	inspectRequestLine(requestLine, inspection.requestLine);
 	if (this->status != COMPLETED)
-		return (this->status);
+		return (finishInspection(*this, inspection, this->status));
 
-	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
+	if (!HttpMessageUtils::findHeaderEnd(rawRequest,
+			inspection.headerEnd,
+			inspection.bodyStart))
 	{
-		this->status = NEED_MORE_DATA;
-		return (this->status);
+		return (finishInspection(*this, inspection, NEED_MORE_DATA));
 	}
 
-	if (headerEnd > MAX_HEADERS_SIZE)
-	{
-		this->status = HEADER_TOO_LARGE;
-		return (this->status);
-	}
+	if (inspection.headerEnd > MAX_HEADERS_SIZE)
+		return (finishInspection(*this, inspection, HEADER_TOO_LARGE));
 
-	headers = rawRequest.substr(0, headerEnd);
+	headers = rawRequest.substr(0, inspection.headerEnd);
+
 	contentLength = 0;
-
-	ContentLengthResult clResult;
 	clResult = getContentLength(headers, contentLength);
-
 	teResult = getTransferEncoding(headers);
-	version = parsedLine.getVersion();
+	version = inspection.requestLine.getVersion();
 
 	if (clResult == CL_INVALID)
-	{
-		this->status = BAD_REQUEST;
-		return (this->status);
-	}
-	if (teResult == TE_INVALID)
-	{
-		this->status = BAD_REQUEST;
-		return (this->status);
-	}
-	if (teResult == TE_UNSUPPORTED)
-	{
-		this->status = NOT_IMPLEMENTED;
-		return (this->status);
-	}
-	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
-	{
-		this->status = BAD_REQUEST;
-		return (this->status);
-	}
-	if (teResult == TE_CHUNKED && clResult == CL_VALID)
-	{
-		this->status = BAD_REQUEST;
-		return (this->status);
-	}
-	if (teResult == TE_CHUNKED)
-	{
-		chunkedStatus = ChunkedDecoder::inspect(
-			rawRequest,
-			bodyStart,
-			maxBodySize,
-			messageEnd);
-		if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
-		{
-			this->status = NEED_MORE_DATA;
-			return (this->status);
-		}
-		if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
-		{
-			this->status = REQUEST_TOO_LARGE;
-			return (this->status);
-		}
-		if (chunkedStatus == CHUNKED_BAD_REQUEST)
-		{
-			this->status = BAD_REQUEST;
-			return (this->status);
-		}
+		return (finishInspection(*this, inspection, BAD_REQUEST));
 
-		this->status = COMPLETED;
-		return (this->status);
-	}
+	if (teResult == TE_INVALID)
+		return (finishInspection(*this, inspection, BAD_REQUEST));
+
+	if (teResult == TE_UNSUPPORTED)
+		return (finishInspection(*this, inspection, NOT_IMPLEMENTED));
+
+	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
+		return (finishInspection(*this, inspection, BAD_REQUEST));
+
+	if (teResult == TE_CHUNKED && clResult == CL_VALID)
+		return (finishInspection(*this, inspection, BAD_REQUEST));
 
 	if (clResult == CL_VALID)
 	{
-		if (contentLength > maxBodySize)
-		{
-			this->status = REQUEST_TOO_LARGE;
-			return (this->status);
-		}
-
-		currentBodySize = rawRequest.length() - bodyStart;
-
-		if (currentBodySize < contentLength)
-		{
-			this->status = NEED_MORE_DATA;
-			return (this->status);
-		}
+		inspection.hasContentLength = true;
+		inspection.contentLength = contentLength;
 	}
 
-	this->status = COMPLETED;
-	return (this->status);
+	inspection.isChunked = (teResult == TE_CHUNKED);
+
+	if (inspection.isChunked)
+	{
+		chunkedStatus = ChunkedDecoder::inspect(
+			rawRequest,
+			inspection.bodyStart,
+			maxBodySize,
+			inspection.messageEnd);
+
+		if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
+			return (finishInspection(*this, inspection, NEED_MORE_DATA));
+
+		if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
+			return (finishInspection(*this, inspection, REQUEST_TOO_LARGE));
+
+		if (chunkedStatus == CHUNKED_BAD_REQUEST)
+			return (finishInspection(*this, inspection, BAD_REQUEST));
+
+		return (finishInspection(*this, inspection, COMPLETED));
+	}
+
+	if (inspection.hasContentLength)
+	{
+		if (inspection.contentLength > maxBodySize)
+			return (finishInspection(*this, inspection, REQUEST_TOO_LARGE));
+
+		currentBodySize = rawRequest.length() - inspection.bodyStart;
+		if (currentBodySize < inspection.contentLength)
+			return (finishInspection(*this, inspection, NEED_MORE_DATA));
+
+		inspection.messageEnd = inspection.bodyStart + inspection.contentLength;
+		return (finishInspection(*this, inspection, COMPLETED));
+	}
+
+	inspection.messageEnd = rawRequest.length();
+	return (finishInspection(*this, inspection, COMPLETED));
 }

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -34,11 +34,10 @@ RequestInspection::RequestInspection()
 	  isChunked(false),
 	  hasContentLength(false),
 	  contentLength(0),
-	  requestLine()
-{}
+	  requestLine() {}
 
 static RequestInspection finishInspection(RequestInspector &inspector,
-	RequestInspection &inspection, InspectRequestStatus status)
+										  RequestInspection &inspection, InspectRequestStatus status)
 {
 	inspection.status = status;
 	inspector.status = status;
@@ -143,16 +142,16 @@ void RequestInspector::inspectRequestLine(const std::string &requestLine, Reques
 
 RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest, size_t maxBodySize)
 {
-	RequestInspection		inspection;
-	std::string				requestLine;
-	std::stringstream		ss;
-	size_t					contentLength;
-	size_t					currentBodySize;
-	std::string				headers;
-	std::string				version;
-	TransferEncodingResult	teResult;
-	ChunkedDecodeStatus		chunkedStatus;
-	ContentLengthResult		clResult;
+	RequestInspection inspection;
+	std::string requestLine;
+	std::stringstream ss;
+	size_t contentLength;
+	size_t currentBodySize;
+	std::string headers;
+	std::string version;
+	TransferEncodingResult teResult;
+	ChunkedDecodeStatus chunkedStatus;
+	ContentLengthResult clResult;
 
 	if (rawRequest.empty())
 		return (finishInspection(*this, inspection, NEED_MORE_DATA));
@@ -165,12 +164,8 @@ RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest
 	if (this->status != COMPLETED)
 		return (finishInspection(*this, inspection, this->status));
 
-	if (!HttpMessageUtils::findHeaderEnd(rawRequest,
-			inspection.headerEnd,
-			inspection.bodyStart))
-	{
+	if (!HttpMessageUtils::findHeaderEnd(rawRequest, inspection.headerEnd, inspection.bodyStart))
 		return (finishInspection(*this, inspection, NEED_MORE_DATA));
-	}
 
 	if (inspection.headerEnd > MAX_HEADERS_SIZE)
 		return (finishInspection(*this, inspection, HEADER_TOO_LARGE));

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -6,14 +6,34 @@
 #include <string>
 #include <sstream>
 
-const std::size_t MAX_HEADERS_SIZE = 32768;
+// const std::size_t MAX_HEADERS_SIZE = 32768;
 
-enum ContentLengthResult
+namespace
 {
-	CL_ABSENT,
-	CL_VALID,
-	CL_INVALID
-};
+	enum ContentLengthResult
+	{
+		CL_ABSENT,
+		CL_VALID,
+		CL_INVALID
+	};
+
+	enum TransferEncodingResult
+	{
+		TE_ABSENT,
+		TE_CHUNKED,
+		TE_UNSUPPORTED,
+		TE_INVALID
+	};
+
+	const std::size_t MAX_HEADERS_SIZE = 32768;
+}
+
+// enum ContentLengthResult
+// {
+// 	CL_ABSENT,
+// 	CL_VALID,
+// 	CL_INVALID
+// };
 
 RequestInspection::RequestInspection()
 	: status(EMPTY),
@@ -68,13 +88,13 @@ static ContentLengthResult getContentLength(const std::string &headers, size_t &
 	return (CL_VALID);
 }
 
-enum TransferEncodingResult
-{
-	TE_ABSENT,
-	TE_CHUNKED,
-	TE_UNSUPPORTED,
-	TE_INVALID
-};
+// enum TransferEncodingResult
+// {
+// 	TE_ABSENT,
+// 	TE_CHUNKED,
+// 	TE_UNSUPPORTED,
+// 	TE_INVALID
+// };
 
 static TransferEncodingResult getTransferEncoding(const std::string &headers)
 {

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -54,10 +54,8 @@ static ContentLengthResult getContentLength(const std::string &headers, size_t &
 		if (key == "content-length")
 		{
 			size_t current = 0;
-			// invalid CL (letters, signs...)
 			if (!HttpMessageUtils::parseSize(value, current))
 				return (CL_INVALID);
-			// conflicting CLs
 			if (found && current != parsed)
 				return (CL_INVALID);
 			parsed = current;
@@ -78,8 +76,7 @@ enum TransferEncodingResult
 	TE_INVALID
 };
 
-static TransferEncodingResult getTransferEncoding(
-	const std::string &headers)
+static TransferEncodingResult getTransferEncoding(const std::string &headers)
 {
 	std::istringstream stream;
 	std::string line;
@@ -141,135 +138,7 @@ void RequestInspector::inspectRequestLine(const std::string &requestLine, Reques
 	this->status = COMPLETED;
 }
 
-// InspectRequestStatus RequestInspector::inspectRequest(const std::string &rawRequest, size_t maxBodySize)
-// {
-// 	std::string requestLine;
-// 	std::stringstream ss;
-// 	size_t headerEnd;
-// 	size_t bodyStart;
-// 	size_t contentLength;
-// 	size_t currentBodySize;
-// 	std::string headers;
-// 	RequestLine parsedLine;
-
-// 	std::string version;
-// 	TransferEncodingResult teResult;
-// 	ChunkedDecodeStatus chunkedStatus;
-// 	size_t messageEnd;
-
-// 	if (rawRequest.empty())
-// 	{
-// 		this->status = NEED_MORE_DATA;
-// 		return (this->status);
-// 	}
-
-// 	ss << rawRequest;
-// 	if (!std::getline(ss, requestLine))
-// 	{
-// 		this->status = NEED_MORE_DATA;
-// 		return (this->status);
-// 	}
-
-// 	inspectRequestLine(requestLine, parsedLine);
-// 	if (this->status != COMPLETED)
-// 		return (this->status);
-
-// 	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
-// 	{
-// 		this->status = NEED_MORE_DATA;
-// 		return (this->status);
-// 	}
-
-// 	if (headerEnd > MAX_HEADERS_SIZE)
-// 	{
-// 		this->status = HEADER_TOO_LARGE;
-// 		return (this->status);
-// 	}
-
-// 	headers = rawRequest.substr(0, headerEnd);
-// 	contentLength = 0;
-
-// 	ContentLengthResult clResult;
-// 	clResult = getContentLength(headers, contentLength);
-
-// 	teResult = getTransferEncoding(headers);
-// 	version = parsedLine.getVersion();
-
-// 	if (clResult == CL_INVALID)
-// 	{
-// 		this->status = BAD_REQUEST;
-// 		return (this->status);
-// 	}
-// 	if (teResult == TE_INVALID)
-// 	{
-// 		this->status = BAD_REQUEST;
-// 		return (this->status);
-// 	}
-// 	if (teResult == TE_UNSUPPORTED)
-// 	{
-// 		this->status = NOT_IMPLEMENTED;
-// 		return (this->status);
-// 	}
-// 	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
-// 	{
-// 		this->status = BAD_REQUEST;
-// 		return (this->status);
-// 	}
-// 	if (teResult == TE_CHUNKED && clResult == CL_VALID)
-// 	{
-// 		this->status = BAD_REQUEST;
-// 		return (this->status);
-// 	}
-// 	if (teResult == TE_CHUNKED)
-// 	{
-// 		chunkedStatus = ChunkedDecoder::inspect(
-// 			rawRequest,
-// 			bodyStart,
-// 			maxBodySize,
-// 			messageEnd);
-// 		if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
-// 		{
-// 			this->status = NEED_MORE_DATA;
-// 			return (this->status);
-// 		}
-// 		if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
-// 		{
-// 			this->status = REQUEST_TOO_LARGE;
-// 			return (this->status);
-// 		}
-// 		if (chunkedStatus == CHUNKED_BAD_REQUEST)
-// 		{
-// 			this->status = BAD_REQUEST;
-// 			return (this->status);
-// 		}
-
-// 		this->status = COMPLETED;
-// 		return (this->status);
-// 	}
-
-// 	if (clResult == CL_VALID)
-// 	{
-// 		if (contentLength > maxBodySize)
-// 		{
-// 			this->status = REQUEST_TOO_LARGE;
-// 			return (this->status);
-// 		}
-
-// 		currentBodySize = rawRequest.length() - bodyStart;
-
-// 		if (currentBodySize < contentLength)
-// 		{
-// 			this->status = NEED_MORE_DATA;
-// 			return (this->status);
-// 		}
-// 	}
-
-// 	this->status = COMPLETED;
-// 	return (this->status);
-// }
-
-RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest,
-	size_t maxBodySize)
+RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest, size_t maxBodySize)
 {
 	RequestInspection		inspection;
 	std::string				requestLine;

--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <sstream>
 
-// const std::size_t MAX_HEADERS_SIZE = 32768;
-
 namespace
 {
 	enum ContentLengthResult
@@ -27,13 +25,6 @@ namespace
 
 	const std::size_t MAX_HEADERS_SIZE = 32768;
 }
-
-// enum ContentLengthResult
-// {
-// 	CL_ABSENT,
-// 	CL_VALID,
-// 	CL_INVALID
-// };
 
 RequestInspection::RequestInspection()
 	: status(EMPTY),
@@ -87,14 +78,6 @@ static ContentLengthResult getContentLength(const std::string &headers, size_t &
 	contentLength = parsed;
 	return (CL_VALID);
 }
-
-// enum TransferEncodingResult
-// {
-// 	TE_ABSENT,
-// 	TE_CHUNKED,
-// 	TE_UNSUPPORTED,
-// 	TE_INVALID
-// };
 
 static TransferEncodingResult getTransferEncoding(const std::string &headers)
 {

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -1,9 +1,7 @@
 #include "RequestParser.hpp"
-#include "RequestLine.hpp"
 #include "ChunkedDecoder.hpp"
 #include "HttpMessageUtils.hpp"
 #include "Request.hpp"
-#include "utils.hpp"
 
 #include <sstream>
 #include <string>
@@ -13,53 +11,6 @@
 #include <sys/types.h>
 #include <iostream>
 #include <map>
-
-// static bool getContentLength(const Request &request, size_t &contentLength)
-// {
-// 	std::map<std::string, std::string>::const_iterator it;
-// 	std::istringstream stream;
-
-// 	it = request.getHeaders().find("content-length");
-// 	if (it == request.getHeaders().end())
-// 		return (false);
-
-// 	stream.str(it->second);
-// 	stream >> contentLength;
-
-// 	if (stream.fail())
-// 		return (false);
-
-// 	return (true);
-// }
-
-// static bool isChunkedRequest(const Request &request)
-// {
-// 	std::map<std::string, std::string>::const_iterator it;
-// 	std::string value;
-
-// 	it = request.getHeaders().find("transfer-encoding");
-
-// 	if (it == request.getHeaders().end())
-// 		return (false);
-
-// 	value = it->second;
-// 	HttpMessageUtils::trimHeaderValue(value);
-// 	value = toLowerCase(value);
-
-// 	return (value == "chunked");
-// }
-
-// static int parseRequestLine(std::string &requestLine, Request &request)
-// {
-// 	RequestLine line;
-
-// 	if (!line.parse(requestLine))
-// 		return (1);
-// 	request.setMethod(line.getMethod());
-// 	request.setPath(line.getUri());
-// 	request.setVersion(line.getVersion());
-// 	return (0);
-// }
 
 static void parseHeader(std::string &header, Request &request)
 {
@@ -73,84 +24,6 @@ static void parseHeader(std::string &header, Request &request)
 
 	request.addHeader(key, value);
 }
-
-// int RequestParser::parse(const std::string &rawRequest, Request &req)
-// {
-// 	size_t headerEnd;
-// 	size_t bodyStart;
-// 	std::string headerPart;
-// 	std::string body;
-// 	std::string requestLine;
-// 	std::string headerLine;
-// 	std::istringstream headerStream;
-// 	size_t contentLength;
-
-// 	if (rawRequest.empty())
-// 		return (1);
-
-// 	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
-// 		return (1);
-
-// 	headerPart = rawRequest.substr(0, headerEnd);
-
-// 	headerStream.str(headerPart);
-
-// 	if (!std::getline(headerStream, requestLine))
-// 		return (1);
-
-// 	if (parseRequestLine(requestLine, req))
-// 		return (1);
-
-// 	while (std::getline(headerStream, headerLine))
-// 	{
-// 		if (headerLine.empty() || headerLine == "\r")
-// 			break;
-// 		parseHeader(headerLine, req);
-// 	}
-
-// 	if (isChunkedRequest(req))
-// 	{
-// 		size_t messageEnd;
-
-// 		if (!ChunkedDecoder::decode(rawRequest, bodyStart, body, messageEnd))
-// 			return (1);
-// 	}
-// 	else
-// 	{
-// 		body = rawRequest.substr(bodyStart);
-
-// 		contentLength = 0;
-
-// 		if (getContentLength(req, contentLength))
-// 		{
-// 			if (body.length() > contentLength)
-// 				body = body.substr(0, contentLength);
-// 		}
-// 	}
-
-// 	req.setBody(body);
-
-// 	std::cout << "Parsed method: " << req.getMethod() << std::endl;
-// 	std::cout << "Parsed path: " << req.getPath() << std::endl;
-// 	std::cout << "Parsed version: " << req.getVersion() << std::endl;
-// 	std::cout << "Parsed body: [" << req.getBody() << "]" << std::endl;
-
-// 	std::cout << "Parsed headers:" << std::endl;
-// 	for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
-// 		 it != req.getHeaders().end(); ++it)
-// 	{
-// 		std::cout << it->first << " = [" << it->second << "]" << std::endl;
-// 	}
-
-// 	if (req.getMethod().empty())
-// 	{
-// 		std::cout << "Failed to parse request\n";
-// 		return (1);
-// 	}
-
-// 	req.setValid();
-// 	return (0);
-// }
 
 int	RequestParser::parse(const std::string &rawRequest, Request &req,
 	const RequestInspection &inspection)

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -25,14 +25,13 @@ static void parseHeader(std::string &header, Request &request)
 	request.addHeader(key, value);
 }
 
-int	RequestParser::parse(const std::string &rawRequest, Request &req,
-	const RequestInspection &inspection)
+int RequestParser::parse(const std::string &rawRequest, Request &req, const RequestInspection &inspection)
 {
-	std::string			headerPart;
-	std::string			body;
-	std::string			headerLine;
-	std::istringstream	headerStream;
-	size_t				messageEnd;
+	std::string headerPart;
+	std::string body;
+	std::string headerLine;
+	std::istringstream headerStream;
+	size_t messageEnd;
 
 	if (inspection.status != COMPLETED)
 		return (1);
@@ -56,18 +55,14 @@ int	RequestParser::parse(const std::string &rawRequest, Request &req,
 
 	if (inspection.isChunked)
 	{
-		if (!ChunkedDecoder::decode(rawRequest,
-				inspection.bodyStart,
-				body,
-				messageEnd))
+		if (!ChunkedDecoder::decode(rawRequest, inspection.bodyStart, body, messageEnd))
 		{
 			return (1);
 		}
 	}
 	else if (inspection.hasContentLength)
 	{
-		body = rawRequest.substr(inspection.bodyStart,
-				inspection.contentLength);
+		body = rawRequest.substr(inspection.bodyStart,inspection.contentLength);
 	}
 	else
 	{
@@ -82,8 +77,8 @@ int	RequestParser::parse(const std::string &rawRequest, Request &req,
 	std::cout << "Parsed body: [" << req.getBody() << "]" << std::endl;
 
 	std::cout << "Parsed headers:" << std::endl;
-	for (std::map<std::string, std::string>::const_iterator it =
-			req.getHeaders().begin(); it != req.getHeaders().end(); ++it)
+	for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
+		 it != req.getHeaders().end(); ++it)
 	{
 		std::cout << it->first << " = [" << it->second << "]" << std::endl;
 	}

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -5,10 +5,6 @@
 
 #include <sstream>
 #include <string>
-#include <cstring>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <sys/types.h>
 #include <iostream>
 #include <map>
 
@@ -62,7 +58,7 @@ int RequestParser::parse(const std::string &rawRequest, Request &req, const Requ
 	}
 	else if (inspection.hasContentLength)
 	{
-		body = rawRequest.substr(inspection.bodyStart,inspection.contentLength);
+		body = rawRequest.substr(inspection.bodyStart, inspection.contentLength);
 	}
 	else
 	{

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -14,52 +14,52 @@
 #include <iostream>
 #include <map>
 
-static bool getContentLength(const Request &request, size_t &contentLength)
-{
-	std::map<std::string, std::string>::const_iterator it;
-	std::istringstream stream;
+// static bool getContentLength(const Request &request, size_t &contentLength)
+// {
+// 	std::map<std::string, std::string>::const_iterator it;
+// 	std::istringstream stream;
 
-	it = request.getHeaders().find("content-length");
-	if (it == request.getHeaders().end())
-		return (false);
+// 	it = request.getHeaders().find("content-length");
+// 	if (it == request.getHeaders().end())
+// 		return (false);
 
-	stream.str(it->second);
-	stream >> contentLength;
+// 	stream.str(it->second);
+// 	stream >> contentLength;
 
-	if (stream.fail())
-		return (false);
+// 	if (stream.fail())
+// 		return (false);
 
-	return (true);
-}
+// 	return (true);
+// }
 
-static bool isChunkedRequest(const Request &request)
-{
-	std::map<std::string, std::string>::const_iterator it;
-	std::string value;
+// static bool isChunkedRequest(const Request &request)
+// {
+// 	std::map<std::string, std::string>::const_iterator it;
+// 	std::string value;
 
-	it = request.getHeaders().find("transfer-encoding");
+// 	it = request.getHeaders().find("transfer-encoding");
 
-	if (it == request.getHeaders().end())
-		return (false);
+// 	if (it == request.getHeaders().end())
+// 		return (false);
 
-	value = it->second;
-	HttpMessageUtils::trimHeaderValue(value);
-	value = toLowerCase(value);
+// 	value = it->second;
+// 	HttpMessageUtils::trimHeaderValue(value);
+// 	value = toLowerCase(value);
 
-	return (value == "chunked");
-}
+// 	return (value == "chunked");
+// }
 
-static int parseRequestLine(std::string &requestLine, Request &request)
-{
-	RequestLine line;
+// static int parseRequestLine(std::string &requestLine, Request &request)
+// {
+// 	RequestLine line;
 
-	if (!line.parse(requestLine))
-		return (1);
-	request.setMethod(line.getMethod());
-	request.setPath(line.getUri());
-	request.setVersion(line.getVersion());
-	return (0);
-}
+// 	if (!line.parse(requestLine))
+// 		return (1);
+// 	request.setMethod(line.getMethod());
+// 	request.setPath(line.getUri());
+// 	request.setVersion(line.getVersion());
+// 	return (0);
+// }
 
 static void parseHeader(std::string &header, Request &request)
 {
@@ -74,31 +74,104 @@ static void parseHeader(std::string &header, Request &request)
 	request.addHeader(key, value);
 }
 
-int RequestParser::parse(const std::string &rawRequest, Request &req)
+// int RequestParser::parse(const std::string &rawRequest, Request &req)
+// {
+// 	size_t headerEnd;
+// 	size_t bodyStart;
+// 	std::string headerPart;
+// 	std::string body;
+// 	std::string requestLine;
+// 	std::string headerLine;
+// 	std::istringstream headerStream;
+// 	size_t contentLength;
+
+// 	if (rawRequest.empty())
+// 		return (1);
+
+// 	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
+// 		return (1);
+
+// 	headerPart = rawRequest.substr(0, headerEnd);
+
+// 	headerStream.str(headerPart);
+
+// 	if (!std::getline(headerStream, requestLine))
+// 		return (1);
+
+// 	if (parseRequestLine(requestLine, req))
+// 		return (1);
+
+// 	while (std::getline(headerStream, headerLine))
+// 	{
+// 		if (headerLine.empty() || headerLine == "\r")
+// 			break;
+// 		parseHeader(headerLine, req);
+// 	}
+
+// 	if (isChunkedRequest(req))
+// 	{
+// 		size_t messageEnd;
+
+// 		if (!ChunkedDecoder::decode(rawRequest, bodyStart, body, messageEnd))
+// 			return (1);
+// 	}
+// 	else
+// 	{
+// 		body = rawRequest.substr(bodyStart);
+
+// 		contentLength = 0;
+
+// 		if (getContentLength(req, contentLength))
+// 		{
+// 			if (body.length() > contentLength)
+// 				body = body.substr(0, contentLength);
+// 		}
+// 	}
+
+// 	req.setBody(body);
+
+// 	std::cout << "Parsed method: " << req.getMethod() << std::endl;
+// 	std::cout << "Parsed path: " << req.getPath() << std::endl;
+// 	std::cout << "Parsed version: " << req.getVersion() << std::endl;
+// 	std::cout << "Parsed body: [" << req.getBody() << "]" << std::endl;
+
+// 	std::cout << "Parsed headers:" << std::endl;
+// 	for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
+// 		 it != req.getHeaders().end(); ++it)
+// 	{
+// 		std::cout << it->first << " = [" << it->second << "]" << std::endl;
+// 	}
+
+// 	if (req.getMethod().empty())
+// 	{
+// 		std::cout << "Failed to parse request\n";
+// 		return (1);
+// 	}
+
+// 	req.setValid();
+// 	return (0);
+// }
+
+int	RequestParser::parse(const std::string &rawRequest, Request &req,
+	const RequestInspection &inspection)
 {
-	size_t headerEnd;
-	size_t bodyStart;
-	std::string headerPart;
-	std::string body;
-	std::string requestLine;
-	std::string headerLine;
-	std::istringstream headerStream;
-	size_t contentLength;
+	std::string			headerPart;
+	std::string			body;
+	std::string			headerLine;
+	std::istringstream	headerStream;
+	size_t				messageEnd;
 
-	if (rawRequest.empty())
+	if (inspection.status != COMPLETED)
 		return (1);
 
-	if (!HttpMessageUtils::findHeaderEnd(rawRequest, headerEnd, bodyStart))
-		return (1);
+	req.setMethod(inspection.requestLine.getMethod());
+	req.setPath(inspection.requestLine.getUri());
+	req.setVersion(inspection.requestLine.getVersion());
 
-	headerPart = rawRequest.substr(0, headerEnd);
-
+	headerPart = rawRequest.substr(0, inspection.headerEnd);
 	headerStream.str(headerPart);
 
-	if (!std::getline(headerStream, requestLine))
-		return (1);
-
-	if (parseRequestLine(requestLine, req))
+	if (!std::getline(headerStream, headerLine))
 		return (1);
 
 	while (std::getline(headerStream, headerLine))
@@ -108,24 +181,24 @@ int RequestParser::parse(const std::string &rawRequest, Request &req)
 		parseHeader(headerLine, req);
 	}
 
-	if (isChunkedRequest(req))
+	if (inspection.isChunked)
 	{
-		size_t messageEnd;
-
-		if (!ChunkedDecoder::decode(rawRequest, bodyStart, body, messageEnd))
+		if (!ChunkedDecoder::decode(rawRequest,
+				inspection.bodyStart,
+				body,
+				messageEnd))
+		{
 			return (1);
+		}
+	}
+	else if (inspection.hasContentLength)
+	{
+		body = rawRequest.substr(inspection.bodyStart,
+				inspection.contentLength);
 	}
 	else
 	{
-		body = rawRequest.substr(bodyStart);
-
-		contentLength = 0;
-
-		if (getContentLength(req, contentLength))
-		{
-			if (body.length() > contentLength)
-				body = body.substr(0, contentLength);
-		}
+		body = rawRequest.substr(inspection.bodyStart);
 	}
 
 	req.setBody(body);
@@ -136,8 +209,8 @@ int RequestParser::parse(const std::string &rawRequest, Request &req)
 	std::cout << "Parsed body: [" << req.getBody() << "]" << std::endl;
 
 	std::cout << "Parsed headers:" << std::endl;
-	for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
-		 it != req.getHeaders().end(); ++it)
+	for (std::map<std::string, std::string>::const_iterator it =
+			req.getHeaders().begin(); it != req.getHeaders().end(); ++it)
 	{
 		std::cout << it->first << " = [" << it->second << "]" << std::endl;
 	}

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -452,19 +452,42 @@ int WebServ::run()
 					RequestParser parser;
 					RequestInspector inspector;
 
-					inspector.inspectRequest(curClient.getRawRequest(), configs[curClient.serverIndex].clientMaxBodySize);
-					if (inspector.status == COMPLETED)
+					// inspector.inspectRequest(curClient.getRawRequest(), configs[curClient.serverIndex].clientMaxBodySize);
+					// if (inspector.status == COMPLETED)
+					// {
+					// 	parser.parse(curClient.getRawRequest(), curClient.request);
+					// }
+					// else if (inspector.status == NEED_MORE_DATA)
+					// {
+					// 	++i;
+					// 	continue;
+					// }
+					// else
+					// {
+					// 	prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex], inspector.status);
+
+					// 	pollManager.setEvents(curFD, POLLOUT);
+					// 	++i;
+					// 	continue;
+					// }
+
+					RequestInspection inspection;
+
+					inspection = inspector.inspectRequest(curClient.getRawRequest(),
+						configs[curClient.serverIndex].clientMaxBodySize);
+					if (inspection.status == COMPLETED)
 					{
-						parser.parse(curClient.getRawRequest(), curClient.request);
+						parser.parse(curClient.getRawRequest(), curClient.request, inspection);
 					}
-					else if (inspector.status == NEED_MORE_DATA)
+					else if (inspection.status == NEED_MORE_DATA)
 					{
 						++i;
 						continue;
 					}
 					else
 					{
-						prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex], inspector.status);
+						prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex],
+							inspection.status);
 
 						pollManager.setEvents(curFD, POLLOUT);
 						++i;

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -451,26 +451,6 @@ int WebServ::run()
 
 					RequestParser parser;
 					RequestInspector inspector;
-
-					// inspector.inspectRequest(curClient.getRawRequest(), configs[curClient.serverIndex].clientMaxBodySize);
-					// if (inspector.status == COMPLETED)
-					// {
-					// 	parser.parse(curClient.getRawRequest(), curClient.request);
-					// }
-					// else if (inspector.status == NEED_MORE_DATA)
-					// {
-					// 	++i;
-					// 	continue;
-					// }
-					// else
-					// {
-					// 	prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex], inspector.status);
-
-					// 	pollManager.setEvents(curFD, POLLOUT);
-					// 	++i;
-					// 	continue;
-					// }
-
 					RequestInspection inspection;
 
 					inspection = inspector.inspectRequest(curClient.getRawRequest(),


### PR DESCRIPTION
This pull request refactors the HTTP request inspection and parsing workflow to improve separation of concerns, reduce redundant logic, and make request parsing more robust. The main change is to have `RequestInspector::inspectRequest` return a detailed `RequestInspection` struct with all relevant parsing metadata, which is then used by `RequestParser::parse` to correctly extract request components. This makes the parsing process more reliable and easier to maintain.

**Refactoring and API changes:**

* Introduced a new `RequestInspection` struct in `RequestInspector.hpp`, which encapsulates the inspection status, header/body/message offsets, chunked/content-length flags, and the parsed `RequestLine`. The `inspectRequest` method now returns this struct instead of just a status, centralizing all inspection results.
* Updated `RequestParser::parse` to accept a `RequestInspection` object, removing redundant header/body parsing logic and relying on the pre-parsed offsets and flags from inspection. This eliminates duplicated code and potential inconsistencies. [[1]](diffhunk://#diff-7a7c5c0d913d5121bf80ea91f8330862e5d148f0f65fadfdcf5037676a77d05fL12-L15) [[2]](diffhunk://#diff-19f8429eec2b6269de118d43245e8c4eeb0eb7f2a1456c882395458106f2b198L77-R42) [[3]](diffhunk://#diff-19f8429eec2b6269de118d43245e8c4eeb0eb7f2a1456c882395458106f2b198L111-R65)
* Refactored `src/RequestInspector.cpp` to build and return a `RequestInspection` object, and to consistently use this struct throughout the inspection process. Added a helper function `finishInspection` for clean status assignment and return. [[1]](diffhunk://#diff-06e9deb5b289d755208679ef2579980f5ae60a16e3437e50c7f55c40c7855100L9-R46) [[2]](diffhunk://#diff-06e9deb5b289d755208679ef2579980f5ae60a16e3437e50c7f55c40c7855100L125-R237)

**Code simplification and cleanup:**

* Removed legacy and redundant parsing functions from `RequestParser.cpp` such as `getContentLength`, `isChunkedRequest`, and `parseRequestLine`, as their logic is now handled in the inspection phase.
* Simplified the main server loop in `WebServ.cpp` to use the new inspection workflow, passing the `RequestInspection` to the parser and error handler, and updating status checks accordingly.

These changes collectively make the HTTP request handling code more modular, easier to follow, and less error-prone.