### PR TITLE
Fix cgi status header

### DIFF
--- a/src/CgiRequestHandler.cpp
+++ b/src/CgiRequestHandler.cpp
@@ -291,3 +291,103 @@ static bool headerNameEquals(const std::string &left, const std::string &right)
 	}
 	return (true);
 }
+
+static bool isContentHeader(const std::string &name)
+{
+	if (headerNameEquals(name, "Content-Length"))
+		return (true);
+
+	if (headerNameEquals(name, "Content-Type"))
+		return (true);
+
+	if (headerNameEquals(name, "Transfer-Encoding"))
+		return (true);
+
+	return (false);
+}
+
+static std::string buildCgiHttpHeaderName(const std::string &name)
+{
+	std::string result;
+	size_t i;
+
+	result = "HTTP_";
+	i = 0;
+	while (i < name.length())
+	{
+		if (name[i] == '-')
+			result += '_';
+		else
+			result += static_cast<char>(std::toupper(static_cast<unsigned char>(name[i])));
+		i++;
+	}
+	return (result);
+}
+
+static void addHttpHeaderVariables(CgiContext &context, const Request &request)
+{
+	std::map<std::string, std::string>::const_iterator it;
+
+	it = request.getHeaders().begin();
+	while (it != request.getHeaders().end())
+	{
+		if (!isContentHeader(it->first))
+		{
+			context.httpHeaders.values[buildCgiHttpHeaderName(it->first)] = trimHeaderValue(it->second);
+		}
+		it++;
+	}
+}
+
+static CgiContext buildCgiContext(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr, const CgiResolvedPath &cgiPath)
+{
+	CgiContext context;
+
+	context.executable = cgiPath.executable;
+	context.scriptPath = cgiPath.scriptPath;
+	context.scriptFileName = PathUtils::getFileName(cgiPath.scriptPath);
+	context.workingDirectory = PathUtils::getDirectoryName(cgiPath.scriptPath);
+	context.requestBody = request.getBody();
+	std::cout << "CGI scriptPath: " << context.scriptPath << std::endl;
+	std::cout << "CGI scriptFileName: " << context.scriptFileName << std::endl;
+	std::cout << "CGI workingDirectory: " << context.workingDirectory << std::endl;
+	std::cout << "Request body for CGI:\n[" << context.requestBody << "]\n";
+	addStandardCgiVariables(context, request, server, remoteAddr, cgiPath);
+	addHttpHeaderVariables(context, request);
+	addImplementationCgiVariables(context, request, route, cgiPath);
+	return (context);
+}
+
+CgiRequestHandler::CgiRequestHandler() {}
+
+CgiRequestHandler::CgiRequestHandler(const CgiRequestHandler &other)
+{
+	(void)other;
+}
+
+CgiRequestHandler &CgiRequestHandler::operator=(const CgiRequestHandler &other)
+{
+	(void)other;
+	return (*this);
+}
+
+CgiRequestHandler::~CgiRequestHandler() {}
+
+bool CgiRequestHandler::isCgiRequest(const Request &request, const RouteConfig &route)
+{
+	CgiResolvedPath cgiPath;
+
+	cgiPath = resolveCgiPath(request, route);
+	return (cgiPath.isCgi);
+}
+
+CgiContext CgiRequestHandler::buildContext(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr)
+{
+	CgiResolvedPath cgiPath;
+
+	cgiPath = resolveCgiPath(request, route);
+	if (!cgiPath.isCgi)
+		return (CgiContext());
+
+	return (buildCgiContext(request, route, server, remoteAddr, cgiPath));
+}

--- a/src/CgiRequestHandler.cpp
+++ b/src/CgiRequestHandler.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 static bool headerNameEquals(const std::string &left, const std::string &right);
+static bool parseCgiStatusCode(const std::string &value, int &statusCode);
 static std::string trimHeaderValue(const std::string &value);
 
 static void addCgiHeaderToResponse(Response &response, const std::string &line)
@@ -22,6 +23,7 @@ static void addCgiHeaderToResponse(Response &response, const std::string &line)
 	size_t colon;
 	std::string name;
 	std::string value;
+	int statusCode;
 
 	colon = line.find(':');
 	if (colon == std::string::npos)
@@ -30,6 +32,12 @@ static void addCgiHeaderToResponse(Response &response, const std::string &line)
 	value = trimHeaderValue(line.substr(colon + 1));
 	if (name.empty())
 		return;
+	if (headerNameEquals(name, "Status"))
+	{
+		if (parseCgiStatusCode(value, statusCode))
+			response.setStatusCode(statusCode);
+		return;
+	}
 	response.addHeader(name, value);
 }
 
@@ -46,6 +54,23 @@ static void addCgiHeadersToResponse(Response &response, const std::string &heade
 		if (!line.empty())
 			addCgiHeaderToResponse(response, line);
 	}
+}
+
+static bool parseCgiStatusCode(const std::string &value, int &statusCode)
+{
+	if (value.length() < 3)
+		return (false);
+	if (!std::isdigit(static_cast<unsigned char>(value[0]))
+		|| !std::isdigit(static_cast<unsigned char>(value[1]))
+		|| !std::isdigit(static_cast<unsigned char>(value[2])))
+		return (false);
+	if (value.length() > 3 && value[3] != ' ' && value[3] != '\t')
+		return (false);
+	statusCode = (value[0] - '0') * 100 + (value[1] - '0') * 10
+		+ (value[2] - '0');
+	if (statusCode < 100 || statusCode > 599)
+		return (false);
+	return (true);
 }
 
 Response CgiRequestHandler::buildResponse(const std::string &cgiOutput)
@@ -265,104 +290,4 @@ static bool headerNameEquals(const std::string &left, const std::string &right)
 		i++;
 	}
 	return (true);
-}
-
-static bool isContentHeader(const std::string &name)
-{
-	if (headerNameEquals(name, "Content-Length"))
-		return (true);
-
-	if (headerNameEquals(name, "Content-Type"))
-		return (true);
-
-	if (headerNameEquals(name, "Transfer-Encoding"))
-		return (true);
-
-	return (false);
-}
-
-static std::string buildCgiHttpHeaderName(const std::string &name)
-{
-	std::string result;
-	size_t i;
-
-	result = "HTTP_";
-	i = 0;
-	while (i < name.length())
-	{
-		if (name[i] == '-')
-			result += '_';
-		else
-			result += static_cast<char>(std::toupper(static_cast<unsigned char>(name[i])));
-		i++;
-	}
-	return (result);
-}
-
-static void addHttpHeaderVariables(CgiContext &context, const Request &request)
-{
-	std::map<std::string, std::string>::const_iterator it;
-
-	it = request.getHeaders().begin();
-	while (it != request.getHeaders().end())
-	{
-		if (!isContentHeader(it->first))
-		{
-			context.httpHeaders.values[buildCgiHttpHeaderName(it->first)] = trimHeaderValue(it->second);
-		}
-		it++;
-	}
-}
-
-static CgiContext buildCgiContext(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr, const CgiResolvedPath &cgiPath)
-{
-	CgiContext context;
-
-	context.executable = cgiPath.executable;
-	context.scriptPath = cgiPath.scriptPath;
-	context.scriptFileName = PathUtils::getFileName(cgiPath.scriptPath);
-	context.workingDirectory = PathUtils::getDirectoryName(cgiPath.scriptPath);
-	context.requestBody = request.getBody();
-	std::cout << "CGI scriptPath: " << context.scriptPath << std::endl;
-	std::cout << "CGI scriptFileName: " << context.scriptFileName << std::endl;
-	std::cout << "CGI workingDirectory: " << context.workingDirectory << std::endl;
-	std::cout << "Request body for CGI:\n[" << context.requestBody << "]\n";
-	addStandardCgiVariables(context, request, server, remoteAddr, cgiPath);
-	addHttpHeaderVariables(context, request);
-	addImplementationCgiVariables(context, request, route, cgiPath);
-	return (context);
-}
-
-CgiRequestHandler::CgiRequestHandler() {}
-
-CgiRequestHandler::CgiRequestHandler(const CgiRequestHandler &other)
-{
-	(void)other;
-}
-
-CgiRequestHandler &CgiRequestHandler::operator=(const CgiRequestHandler &other)
-{
-	(void)other;
-	return (*this);
-}
-
-CgiRequestHandler::~CgiRequestHandler() {}
-
-bool CgiRequestHandler::isCgiRequest(const Request &request, const RouteConfig &route)
-{
-	CgiResolvedPath cgiPath;
-
-	cgiPath = resolveCgiPath(request, route);
-	return (cgiPath.isCgi);
-}
-
-CgiContext CgiRequestHandler::buildContext(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr)
-{
-	CgiResolvedPath cgiPath;
-
-	cgiPath = resolveCgiPath(request, route);
-	if (!cgiPath.isCgi)
-		return (CgiContext());
-
-	return (buildCgiContext(request, route, server, remoteAddr, cgiPath));
 }


### PR DESCRIPTION
This pull request updates the CGI response handling logic to correctly process the `Status` header from CGI scripts. The main improvement is that the server now parses the status code from the `Status` header and sets it on the response, rather than treating it as a regular header.

**CGI Status Header Handling:**

* Added logic in `addCgiHeaderToResponse` to detect the `Status` header and set the response status code accordingly, instead of adding it as a normal header.
* Introduced the helper function `parseCgiStatusCode` to robustly parse and validate the status code from the `Status` header value. [[1]](diffhunk://#diff-516319f4adee696890930f4137219095a70a4756d43cf35500b1c3e160e45d1cR18-R26) [[2]](diffhunk://#diff-516319f4adee696890930f4137219095a70a4756d43cf35500b1c3e160e45d1cR59-R75)