### PR TITLE
Fix client max body size

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -4,10 +4,11 @@
 # include <ctime>
 # include <sys/types.h>
 
-enum ClientState
+ enum ClientState
 {
   WRITING,
   READING,
+  DISCARDING_BODY,
   CGI_WRITING,
   CGI_READING,
   CLOSING_CONNECTION
@@ -38,6 +39,7 @@ class Client
     size_t serverIndex;
     std::string responseBuffer;
     size_t bytesSent;
+    size_t bodyBytesToDiscard;
     bool responseReady;
     pid_t cgiPid;
     int cgiStdinFd;

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -1,10 +1,11 @@
 #ifndef CLIENT_HPP
 # define CLIENT_HPP
 # include "Request.hpp"
+# include <cstddef>
 # include <ctime>
 # include <sys/types.h>
 
- enum ClientState
+enum ClientState
 {
   WRITING,
   READING,

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -35,6 +35,7 @@ private:
 	CgiManager cgiManager;
 
 	int setNonBlocking(int fd);
+	int discardRequestBody(Client &client);
 	void closeAndRemoveFd(int fd);
 	std::vector<ServerConfig> configs;
 	std::map<int, size_t> listenerFdToIndex;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -10,6 +10,7 @@ Client::Client(int fd)
       state(READING),
       serverIndex(0),
       bytesSent(0),
+      bodyBytesToDiscard(0),
       responseReady(false),
       cgiPid(-1),
       cgiStdinFd(-1),

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -84,6 +84,44 @@ int WebServ::readFromClient(Client &client)
 	return (0);
 }
 
+int WebServ::discardRequestBody(Client &client)
+{
+	ssize_t bytesRead;
+	char buffer[4096];
+	size_t readSize;
+
+	if (client.bodyBytesToDiscard == 0)
+	{
+		client.state = WRITING;
+		return (0);
+	}
+	readSize = sizeof(buffer);
+	if (client.bodyBytesToDiscard < readSize)
+		readSize = client.bodyBytesToDiscard;
+	bytesRead = recv(client.fd, buffer, readSize, 0);
+	if (bytesRead < 0)
+	{
+		std::cerr << "Failed to discard request body from client fd "
+				  << client.fd << std::endl;
+		client.state = CLOSING_CONNECTION;
+		return (1);
+	}
+	if (bytesRead == 0)
+	{
+		client.bodyBytesToDiscard = 0;
+		client.state = WRITING;
+		return (0);
+	}
+	if (static_cast<size_t>(bytesRead) >= client.bodyBytesToDiscard)
+	{
+		client.bodyBytesToDiscard = 0;
+		client.state = WRITING;
+	}
+	else
+		client.bodyBytesToDiscard -= static_cast<size_t>(bytesRead);
+	return (0);
+}
+
 int WebServ::SendToClient(Client &client)
 {
 	RequestDispatcher::Result dispatchResult;
@@ -94,7 +132,7 @@ int WebServ::SendToClient(Client &client)
 	if (!client.responseReady)
 	{
 		dispatchResult = RequestDispatcher::dispatch(client, configs[client.serverIndex],
-													 cgiManager, pollManager);
+											 cgiManager, pollManager);
 
 		if (dispatchResult == RequestDispatcher::DISPATCH_FAILED)
 			return (1);
@@ -354,6 +392,23 @@ static void prepareInspectorErrorResponse(Client &client, const ServerConfig &se
 	client.state = WRITING;
 }
 
+static void prepareBodyDiscard(Client &client, const RequestInspection &inspection)
+{
+	size_t currentBodySize;
+
+	client.bodyBytesToDiscard = 0;
+	if (!inspection.hasContentLength)
+		return;
+	currentBodySize = 0;
+	if (client.rawRequest.length() > inspection.bodyStart)
+		currentBodySize = client.rawRequest.length() - inspection.bodyStart;
+	if (currentBodySize < inspection.contentLength)
+	{
+		client.bodyBytesToDiscard = inspection.contentLength - currentBodySize;
+		client.state = DISCARDING_BODY;
+	}
+}
+
 int WebServ::run()
 {
 	std::cout << "WebServ run called!\n";
@@ -424,6 +479,22 @@ int WebServ::run()
 				}
 
 				Client &curClient = clientIt->second;
+				if (curClient.state == DISCARDING_BODY)
+				{
+					if (pollFds[i].revents & POLLIN)
+					{
+						discardRequestBody(curClient);
+						if (curClient.state == CLOSING_CONNECTION)
+						{
+							closeAndRemoveFd(curFD);
+							continue;
+						}
+						if (curClient.state == WRITING)
+							pollManager.setEvents(curFD, POLLOUT);
+					}
+					++i;
+					continue;
+				}
 				if (curClient.state == CGI_WRITING || curClient.state == CGI_READING)
 				{
 					if (pollFds[i].revents & POLLIN)
@@ -468,8 +539,12 @@ int WebServ::run()
 					{
 						prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex],
 							inspection.status);
-
-						pollManager.setEvents(curFD, POLLOUT);
+						if (inspection.status == REQUEST_TOO_LARGE)
+							prepareBodyDiscard(curClient, inspection);
+						if (curClient.state == DISCARDING_BODY)
+							pollManager.setEvents(curFD, POLLIN);
+						else
+							pollManager.setEvents(curFD, POLLOUT);
 						++i;
 						continue;
 					}


### PR DESCRIPTION
This pull request improves how the server handles HTTP requests with bodies that need to be discarded, particularly in error scenarios such as when the request is too large. The main changes introduce a new client state for discarding request bodies, implement logic to track and discard the remaining body bytes, and update the event loop to handle this new state efficiently.

**Request body discarding improvements:**

* Added a new `DISCARDING_BODY` state to the `ClientState` enum in `Client.hpp` to represent when the server is actively discarding the remainder of a request body.
* Added a `bodyBytesToDiscard` member to the `Client` class to track how many bytes of the request body still need to be read and discarded. [[1]](diffhunk://#diff-e51bf9f83fe8e45333b20bd892f51a986ad580840527fc25cb55224675ed95eeR43) [[2]](diffhunk://#diff-0070ad6232aacef7bac0064510add28e8fae5d8bc8e0475d2c17f38c3a5b836fR13)
* Implemented the `discardRequestBody(Client &client)` method in `WebServ.cpp` to read and discard the appropriate number of bytes from the client socket, updating the client state as needed. [[1]](diffhunk://#diff-cbaac149b8e958d07fc172d27917861e41377c210326346ca80b2b84eb1d04f9R38) [[2]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR87-R124)

**Event loop and error handling integration:**

* Added the `prepareBodyDiscard` helper to set up discarding of the request body when a request is too large, and updated the event loop in `WebServ::run()` to handle the new `DISCARDING_BODY` state, ensuring the server continues reading until the body is fully discarded before proceeding. [[1]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR395-R411) [[2]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dR482-R497) [[3]](diffhunk://#diff-cab771a74de60d81ae8038744a17df73efdfe2f818c3459015507dec64614e9dL471-R546)