### PR TITLE
Check for explicit body framing before validating empty request body

### DIFF
--- a/src/UploadHandler.cpp
+++ b/src/UploadHandler.cpp
@@ -16,6 +16,14 @@ static Response buildCreatedResponse()
 	return (response);
 }
 
+static bool hasExplicitBodyFraming(const Request &request)
+{
+	const std::map<std::string, std::string> &headers = request.getHeaders();
+
+	return (headers.find("content-length") != headers.end()
+		|| headers.find("transfer-encoding") != headers.end());
+}
+
 static Response writeUploadedFile(const Request &request, const std::string &fullPath, const ServerConfig &server)
 {
 	std::ofstream file;
@@ -53,7 +61,7 @@ Response UploadHandler::handle(const Request &request, const RouteConfig &route,
 		return (ErrorResponseHandler::build(500, "Internal Server Error: Upload store not configured", server));
 
 	// 3. Check the body
-	if (request.getBody().empty())
+	if (request.getBody().empty() && !hasExplicitBodyFraming(request))
 		return (ErrorResponseHandler::build(400, "Bad request: Empty body", server));
 
 	// 4. Extraction and safety check of the filename


### PR DESCRIPTION
This pull request introduces improved handling for HTTP request bodies in the upload handler. The main change is that the server now checks for explicit body framing headers before rejecting requests with empty bodies, aligning behavior more closely with HTTP standards.

**HTTP request body handling improvements:**

* Added the `hasExplicitBodyFraming` helper function to check for `content-length` or `transfer-encoding` headers in the request, which indicate an explicit body framing. (`src/UploadHandler.cpp`)
* Updated the upload handler logic to only reject empty request bodies if there is no explicit body framing, preventing incorrect 400 errors for valid requests. (`src/UploadHandler.cpp`)