### PR TITLE
Refactor CGI validation into CgiValidator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp CgiSession.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiValidator.hpp
+++ b/include/CgiValidator.hpp
@@ -1,0 +1,18 @@
+#ifndef CGI_VALIDATOR_HPP
+# define CGI_VALIDATOR_HPP
+
+# include "CgiHandler.hpp"
+# include <string>
+
+class CgiValidator
+{
+	public:
+		static int			validate(const CgiContext &context);
+		static std::string	messageForStatus(int statusCode);
+
+	private:
+		static int	checkScriptPath(const std::string &scriptPath);
+		static int	checkExecutablePath(const std::string &executablePath);
+};
+
+#endif

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,11 +1,11 @@
 #include "CgiManager.hpp"
 #include "CgiRequestHandler.hpp"
+#include "CgiValidator.hpp"
 #include "ErrorResponseHandler.hpp"
 #include "Response.hpp"
 #include "CgiHandler.hpp"
 
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <ctime>
 #include <iostream>
 #include <signal.h>
@@ -30,83 +30,15 @@ CgiManager &CgiManager::operator=(const CgiManager &other)
 	return (*this);
 }
 
-static std::string getCgiValidationMessage(int statusCode)
-{
-	if (statusCode == 403)
-		return ("Forbidden");
-	if (statusCode == 404)
-		return ("Not Found");
-	if (statusCode == 502)
-		return ("Bad Gateway");
-	return ("Internal Server Error");
-}
-
 static void prepareCgiErrorResponse(Client &client, const ServerConfig &server, int statusCode)
 {
 	Response error;
 
-	error = ErrorResponseHandler::build(statusCode, getCgiValidationMessage(statusCode), server);
+	error = ErrorResponseHandler::build(statusCode, CgiValidator::messageForStatus(statusCode), server);
 	client.responseBuffer = error.toString();
 	client.bytesSent = 0;
 	client.responseReady = true;
 	client.state = WRITING;
-}
-
-static int checkCgiScriptPath(const std::string &scriptPath)
-{
-	struct stat scriptStat;
-
-	if (scriptPath.empty())
-		return (404);
-
-	if (stat(scriptPath.c_str(), &scriptStat) == -1)
-	{
-		if (errno == ENOENT || errno == ENOTDIR)
-			return (404);
-		return (403);
-	}
-
-	if (S_ISDIR(scriptStat.st_mode))
-		return (403);
-
-	if (access(scriptPath.c_str(), R_OK) == -1)
-		return (403);
-
-	return (0);
-}
-
-static int checkCgiExecutablePath(const std::string &executablePath)
-{
-	struct stat executableStat;
-
-	if (executablePath.empty())
-		return (502);
-
-	if (stat(executablePath.c_str(), &executableStat) == -1)
-		return (502);
-
-	if (S_ISDIR(executableStat.st_mode))
-		return (502);
-
-	if (access(executablePath.c_str(), X_OK) == -1)
-		return (502);
-
-	return (0);
-}
-
-static int validateCgiContext(const CgiContext &context)
-{
-	int statusCode;
-
-	statusCode = checkCgiScriptPath(context.scriptPath);
-	if (statusCode != 0)
-		return (statusCode);
-
-	statusCode = checkCgiExecutablePath(context.executable);
-	if (statusCode != 0)
-		return (statusCode);
-
-	return (0);
 }
 
 static int setNonBlockingFd(int fd)
@@ -429,7 +361,7 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 
 	context = CgiRequestHandler::buildContext(client.request, route, server, client.getRemoteAddr());
 
-	validationStatus = validateCgiContext(context);
+	validationStatus = CgiValidator::validate(context);
 	if (validationStatus != 0)
 	{
 		prepareCgiErrorResponse(client, server, validationStatus);

--- a/src/CgiValidator.cpp
+++ b/src/CgiValidator.cpp
@@ -1,0 +1,63 @@
+#include "CgiValidator.hpp"
+
+#include <cerrno>
+#include <sys/stat.h>
+#include <unistd.h>
+
+std::string	CgiValidator::messageForStatus(int statusCode)
+{
+	if (statusCode == 403)
+		return ("Forbidden");
+	if (statusCode == 404)
+		return ("Not Found");
+	if (statusCode == 502)
+		return ("Bad Gateway");
+	return ("Internal Server Error");
+}
+
+int	CgiValidator::checkScriptPath(const std::string &scriptPath)
+{
+	struct stat	scriptStat;
+
+	if (scriptPath.empty())
+		return (404);
+	if (stat(scriptPath.c_str(), &scriptStat) == -1)
+	{
+		if (errno == ENOENT || errno == ENOTDIR)
+			return (404);
+		return (403);
+	}
+	if (S_ISDIR(scriptStat.st_mode))
+		return (403);
+	if (access(scriptPath.c_str(), R_OK) == -1)
+		return (403);
+	return (0);
+}
+
+int	CgiValidator::checkExecutablePath(const std::string &executablePath)
+{
+	struct stat	executableStat;
+
+	if (executablePath.empty())
+		return (502);
+	if (stat(executablePath.c_str(), &executableStat) == -1)
+		return (502);
+	if (S_ISDIR(executableStat.st_mode))
+		return (502);
+	if (access(executablePath.c_str(), X_OK) == -1)
+		return (502);
+	return (0);
+}
+
+int	CgiValidator::validate(const CgiContext &context)
+{
+	int	statusCode;
+
+	statusCode = checkScriptPath(context.scriptPath);
+	if (statusCode != 0)
+		return (statusCode);
+	statusCode = checkExecutablePath(context.executable);
+	if (statusCode != 0)
+		return (statusCode);
+	return (0);
+}


### PR DESCRIPTION
## Summary

This PR extracts CGI target validation logic from `CgiManager` into a dedicated `CgiValidator` component.

## Changes

- Add `include/CgiValidator.hpp`
- Add `src/CgiValidator.cpp`
- Move CGI status message mapping into `CgiValidator::messageForStatus`
- Move CGI script path validation into `CgiValidator`
- Move CGI executable path validation into `CgiValidator`
- Replace local validation helpers in `CgiManager` with `CgiValidator::validate(context)`
- Add `CgiValidator.cpp` to the Makefile

## Intent

This is a mechanical architecture refactor. It should not change CGI process startup, pipe I/O, poll handling, timeout handling, or response flow.

## Validation checklist

- [ ] `make fclean && make`
- [ ] second `make` does not relink unnecessarily
- [ ] regression baseline has no new differences
- [ ] stress tests produce no new failures
