### PR TITLE
Fix upload_store validation at startup

### DIFF
--- a/src/ConfigValidator.cpp
+++ b/src/ConfigValidator.cpp
@@ -7,6 +7,8 @@
 #include <set>
 #include <sstream>
 #include <stdexcept>
+#include <sys/stat.h>
+#include <unistd.h>
 
 static std::runtime_error configError(const std::string &message)
 {
@@ -169,6 +171,18 @@ static void validateCgiConfig(const RouteConfig &route)
 	}
 }
 
+static void validateUploadStoreDirectory(const RouteConfig &route)
+{
+	struct stat pathStat;
+
+	if (stat(route.uploadStore.c_str(), &pathStat) != 0)
+		throw configError("location " + route.path + " upload_store does not exist or is inaccessible: " + route.uploadStore);
+	if (!S_ISDIR(pathStat.st_mode))
+		throw configError("location " + route.path + " upload_store is not a directory: " + route.uploadStore);
+	if (access(route.uploadStore.c_str(), W_OK) != 0)
+		throw configError("location " + route.path + " upload_store is not writable: " + route.uploadStore);
+}
+
 static void validateRoutePaths(const RouteConfig &route)
 {
 	if (!isValidLocationPath(route.path))
@@ -190,6 +204,8 @@ static void validateRoute(const RouteConfig &route)
 		throw configError("location " + route.path + " has upload_enable on but upload_store is missing");
 	if (!route.uploadEnable && !route.uploadStore.empty())
 		throw configError("location " + route.path + " has upload_store but upload_enable is off");
+	if (route.uploadEnable)
+		validateUploadStoreDirectory(route);
 	if (route.hasReturn && !isRedirectStatusCode(route.returnCode))
 		throw configError("location " + route.path + " has invalid redirect status code");
 	if (route.hasReturn && !isValidRedirectTarget(route.returnPath))


### PR DESCRIPTION
## Summary

Validate configured `upload_store` directories during config validation instead of waiting until a POST upload request.

## Changes

- Add startup validation for `upload_store` when `upload_enable on` is configured
- Reject missing/inaccessible upload directories
- Reject `upload_store` paths that are not directories
- Reject upload directories without write permission
- Keep the existing `upload_enable on` + missing `upload_store` validation

Closes #118

## Validation checklist

- [ ] `make fclean && make`
- [ ] second `make` does not relink unnecessarily
- [ ] regression tester still passes
- [ ] manual invalid config test: missing upload_store path exits before listening
- [ ] manual invalid config test: upload_store points to a regular file exits before listening
- [ ] manual invalid config test: upload_store exists but is not writable exits before listening

Note: I could not run the local build/tests from this environment because cloning/running the repository locally was unavailable here.