### PR TITLE
Refactor CGI pipe I/O helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp Client.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiPipeIO.cpp Client.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiPipeIO.hpp
+++ b/include/CgiPipeIO.hpp
@@ -1,0 +1,24 @@
+#ifndef CGI_PIPE_IO_HPP
+# define CGI_PIPE_IO_HPP
+
+# include "CgiSession.hpp"
+
+class CgiPipeIO
+{
+	public:
+		enum ReadResult
+		{
+			READ_OK,
+			READ_EOF,
+			READ_ERROR
+		};
+
+		static bool		hasInputFinished(const CgiSession &session);
+		static int		writeToStdin(CgiSession &session);
+		static ReadResult	readFromStdout(CgiSession &session);
+
+	private:
+		CgiPipeIO();
+};
+
+#endif

--- a/include/CgiPipeIO.hpp
+++ b/include/CgiPipeIO.hpp
@@ -1,7 +1,7 @@
 #ifndef CGI_PIPE_IO_HPP
-# define CGI_PIPE_IO_HPP
+#define CGI_PIPE_IO_HPP
 
-# include "CgiSession.hpp"
+#include "CgiSession.hpp"
 
 class CgiPipeIO
 {
@@ -13,9 +13,9 @@ class CgiPipeIO
 			READ_ERROR
 		};
 
-		static bool		hasInputFinished(const CgiSession &session);
-		static int		writeToStdin(CgiSession &session);
-		static ReadResult	readFromStdout(CgiSession &session);
+		static bool hasInputFinished(const CgiSession &session);
+		static int writeToStdin(CgiSession &session);
+		static ReadResult readFromStdout(CgiSession &session);
 
 	private:
 		CgiPipeIO();

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,5 +1,6 @@
 #include "CgiManager.hpp"
 #include "CgiRequestHandler.hpp"
+#include "CgiPipeIO.hpp"
 #include "CgiValidator.hpp"
 #include "ErrorResponseHandler.hpp"
 #include "Response.hpp"
@@ -111,14 +112,10 @@ void CgiManager::cleanup(Client &client, PollManager &pollManager)
 
 int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 {
-	size_t remaining;
-	ssize_t bytesWritten;
-
 	if (client.cgi.stdinFd == -1 || client.cgi.stdinClosed)
 		return (0);
 
-	remaining = client.cgi.inputBuffer.size() - client.cgi.inputSent;
-	if (remaining == 0)
+	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
 		closeCgiFd(client.cgi.stdinFd, pollManager);
 		client.cgi.stdinFd = -1;
@@ -126,17 +123,10 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 		return (0);
 	}
 
-	bytesWritten = write(client.cgi.stdinFd, client.cgi.inputBuffer.c_str() + client.cgi.inputSent, remaining);
-
-	if (bytesWritten <= 0)
-	{
-		std::cerr << "Failed to write request body to CGI" << std::endl;
+	if (CgiPipeIO::writeToStdin(client.cgi) != 0)
 		return (1);
-	}
 
-	client.cgi.inputSent += static_cast<size_t>(bytesWritten);
-
-	if (client.cgi.inputSent >= client.cgi.inputBuffer.size())
+	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
 		closeCgiFd(client.cgi.stdinFd, pollManager);
 		client.cgi.stdinFd = -1;
@@ -148,27 +138,20 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 
 int CgiManager::readFromCgi(Client &client, PollManager &pollManager)
 {
-	char buffer[4096];
-	ssize_t bytesRead;
+	CgiPipeIO::ReadResult result;
 
 	if (client.cgi.stdoutFd == -1 || client.cgi.stdoutClosed)
 		return (0);
 
-	bytesRead = read(client.cgi.stdoutFd, buffer, sizeof(buffer));
-	if (bytesRead < 0)
-	{
-		std::cerr << "Failed to read CGI output" << std::endl;
+	result = CgiPipeIO::readFromStdout(client.cgi);
+	if (result == CgiPipeIO::READ_ERROR)
 		return (1);
-	}
-	if (bytesRead == 0)
+	if (result == CgiPipeIO::READ_EOF)
 	{
 		closeCgiFd(client.cgi.stdoutFd, pollManager);
 		client.cgi.stdoutFd = -1;
 		client.cgi.stdoutClosed = true;
-		return (0);
 	}
-
-	client.cgi.outputBuffer.append(buffer, static_cast<size_t>(bytesRead));
 	return (0);
 }
 

--- a/src/CgiPipeIO.cpp
+++ b/src/CgiPipeIO.cpp
@@ -3,19 +3,19 @@
 #include <iostream>
 #include <unistd.h>
 
-bool	CgiPipeIO::hasInputFinished(const CgiSession &session)
+bool CgiPipeIO::hasInputFinished(const CgiSession &session)
 {
 	return (session.inputSent >= session.inputBuffer.size());
 }
 
-int	CgiPipeIO::writeToStdin(CgiSession &session)
+int CgiPipeIO::writeToStdin(CgiSession &session)
 {
-	size_t	remaining;
-	ssize_t	bytesWritten;
+	size_t remaining;
+	ssize_t bytesWritten;
 
 	remaining = session.inputBuffer.size() - session.inputSent;
 	bytesWritten = write(session.stdinFd,
-		session.inputBuffer.c_str() + session.inputSent, remaining);
+						 session.inputBuffer.c_str() + session.inputSent, remaining);
 	if (bytesWritten <= 0)
 	{
 		std::cerr << "Failed to write request body to CGI" << std::endl;
@@ -25,10 +25,10 @@ int	CgiPipeIO::writeToStdin(CgiSession &session)
 	return (0);
 }
 
-CgiPipeIO::ReadResult	CgiPipeIO::readFromStdout(CgiSession &session)
+CgiPipeIO::ReadResult CgiPipeIO::readFromStdout(CgiSession &session)
 {
-	char	buffer[4096];
-	ssize_t	bytesRead;
+	char buffer[4096];
+	ssize_t bytesRead;
 
 	bytesRead = read(session.stdoutFd, buffer, sizeof(buffer));
 	if (bytesRead < 0)

--- a/src/CgiPipeIO.cpp
+++ b/src/CgiPipeIO.cpp
@@ -1,0 +1,43 @@
+#include "CgiPipeIO.hpp"
+
+#include <iostream>
+#include <unistd.h>
+
+bool	CgiPipeIO::hasInputFinished(const CgiSession &session)
+{
+	return (session.inputSent >= session.inputBuffer.size());
+}
+
+int	CgiPipeIO::writeToStdin(CgiSession &session)
+{
+	size_t	remaining;
+	ssize_t	bytesWritten;
+
+	remaining = session.inputBuffer.size() - session.inputSent;
+	bytesWritten = write(session.stdinFd,
+		session.inputBuffer.c_str() + session.inputSent, remaining);
+	if (bytesWritten <= 0)
+	{
+		std::cerr << "Failed to write request body to CGI" << std::endl;
+		return (1);
+	}
+	session.inputSent += static_cast<size_t>(bytesWritten);
+	return (0);
+}
+
+CgiPipeIO::ReadResult	CgiPipeIO::readFromStdout(CgiSession &session)
+{
+	char	buffer[4096];
+	ssize_t	bytesRead;
+
+	bytesRead = read(session.stdoutFd, buffer, sizeof(buffer));
+	if (bytesRead < 0)
+	{
+		std::cerr << "Failed to read CGI output" << std::endl;
+		return (READ_ERROR);
+	}
+	if (bytesRead == 0)
+		return (READ_EOF);
+	session.outputBuffer.append(buffer, static_cast<size_t>(bytesRead));
+	return (READ_OK);
+}


### PR DESCRIPTION
## Summary

This PR extracts low-level CGI pipe read/write logic from `CgiManager` into a dedicated `CgiPipeIO` helper.

## Changes

- Add `include/CgiPipeIO.hpp`
- Add `src/CgiPipeIO.cpp`
- Move CGI stdin write logic into `CgiPipeIO::writeToStdin`
- Move CGI stdout read logic into `CgiPipeIO::readFromStdout`
- Add `CgiPipeIO::hasInputFinished`
- Keep fd closing, poll removal and fd unregistering in `CgiManager`
- Add `CgiPipeIO.cpp` to the Makefile

## Intent

This is a mechanical architecture refactor. It should not change CGI process startup, fd mapping, poll lifecycle, timeout handling, response building, or cleanup behaviour.

## Validation checklist

- [ ] `make fclean && make`
- [ ] second `make` does not relink unnecessarily
- [ ] regression baseline has no new differences
- [ ] stress tests produce no new failures
