### PR TITLE
Refactor client response application helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiPipeIO.cpp Client.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiPipeIO.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/ClientResponseApplier.hpp
+++ b/include/ClientResponseApplier.hpp
@@ -1,13 +1,13 @@
 #ifndef CLIENT_RESPONSE_APPLIER_HPP
-# define CLIENT_RESPONSE_APPLIER_HPP
+#define CLIENT_RESPONSE_APPLIER_HPP
 
-# include "Client.hpp"
-# include "Response.hpp"
+#include "Client.hpp"
+#include "Response.hpp"
 
 class ClientResponseApplier
 {
 	public:
-		static void	apply(Client &client, const Response &response);
+		static void apply(Client &client, const Response &response);
 
 	private:
 		ClientResponseApplier();

--- a/include/ClientResponseApplier.hpp
+++ b/include/ClientResponseApplier.hpp
@@ -1,0 +1,16 @@
+#ifndef CLIENT_RESPONSE_APPLIER_HPP
+# define CLIENT_RESPONSE_APPLIER_HPP
+
+# include "Client.hpp"
+# include "Response.hpp"
+
+class ClientResponseApplier
+{
+	public:
+		static void	apply(Client &client, const Response &response);
+
+	private:
+		ClientResponseApplier();
+};
+
+#endif

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,4 +1,5 @@
 #include "CgiManager.hpp"
+#include "ClientResponseApplier.hpp"
 #include "CgiRequestHandler.hpp"
 #include "CgiPipeIO.hpp"
 #include "CgiValidator.hpp"
@@ -36,10 +37,7 @@ static void prepareCgiErrorResponse(Client &client, const ServerConfig &server, 
 	Response error;
 
 	error = ErrorResponseHandler::build(statusCode, CgiValidator::messageForStatus(statusCode), server);
-	client.responseBuffer = error.toString();
-	client.bytesSent = 0;
-	client.responseReady = true;
-	client.state = WRITING;
+	ClientResponseApplier::apply(client, error);
 }
 
 static int setNonBlockingFd(int fd)
@@ -242,10 +240,7 @@ void CgiManager::finishResponse(Client &client, PollManager &pollManager)
 	Response response;
 
 	response = CgiRequestHandler::buildResponse(client.cgi.outputBuffer);
-	client.responseBuffer = response.toString();
-	client.bytesSent = 0;
-	client.responseReady = true;
-	client.state = WRITING;
+	ClientResponseApplier::apply(client, response);
 	client.cgi.reset();
 	pollManager.setEvents(client.fd, POLLOUT);
 }
@@ -257,10 +252,7 @@ void CgiManager::failResponse(Client &client, int code, const std::string &messa
 
 	cleanup(client, pollManager);
 	response = ErrorResponseHandler::build(code, message, server);
-	client.responseBuffer = response.toString();
-	client.bytesSent = 0;
-	client.responseReady = true;
-	client.state = WRITING;
+	ClientResponseApplier::apply(client, response);
 	pollManager.setEvents(client.fd, POLLOUT);
 }
 
@@ -357,10 +349,7 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 		Response error;
 
 		error = ErrorResponseHandler::build(502, "Bad Gateway", server);
-		client.responseBuffer = error.toString();
-		client.bytesSent = 0;
-		client.responseReady = true;
-		client.state = WRITING;
+		ClientResponseApplier::apply(client, error);
 		pollManager.setEvents(client.fd, POLLOUT);
 		return (1);
 	}
@@ -375,10 +364,7 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 		Response error;
 
 		error = ErrorResponseHandler::build(500, "Internal Server Error", server);
-		client.responseBuffer = error.toString();
-		client.bytesSent = 0;
-		client.responseReady = true;
-		client.state = WRITING;
+		ClientResponseApplier::apply(client, error);
 		pollManager.setEvents(client.fd, POLLOUT);
 		return (1);
 	}

--- a/src/ClientResponseApplier.cpp
+++ b/src/ClientResponseApplier.cpp
@@ -1,0 +1,9 @@
+#include "ClientResponseApplier.hpp"
+
+void	ClientResponseApplier::apply(Client &client, const Response &response)
+{
+	client.responseBuffer = response.toString();
+	client.bytesSent = 0;
+	client.responseReady = true;
+	client.state = WRITING;
+}

--- a/src/ClientResponseApplier.cpp
+++ b/src/ClientResponseApplier.cpp
@@ -1,6 +1,6 @@
 #include "ClientResponseApplier.hpp"
 
-void	ClientResponseApplier::apply(Client &client, const Response &response)
+void ClientResponseApplier::apply(Client &client, const Response &response)
 {
 	client.responseBuffer = response.toString();
 	client.bytesSent = 0;

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "CgiHandler.hpp"
+#include "ClientResponseApplier.hpp"
 #include "RequestDispatcher.hpp"
 #include "ErrorResponseHandler.hpp"
 
@@ -384,11 +385,7 @@ static void prepareInspectorErrorResponse(Client &client, const ServerConfig &se
 		statusCode = 400;
 
 	response = ErrorResponseHandler::build(statusCode, getInspectorErrorMessage(status), server);
-
-	client.responseBuffer = response.toString();
-	client.bytesSent = 0;
-	client.responseReady = true;
-	client.state = WRITING;
+	ClientResponseApplier::apply(client, response);
 }
 
 static void prepareBodyDiscard(Client &client, const RequestInspection &inspection)


### PR DESCRIPTION
## Summary

This PR extracts the repeated logic that applies a built `Response` to a `Client` into a dedicated `ClientResponseApplier` helper.

## Changes

- Add `include/ClientResponseApplier.hpp`
- Add `src/ClientResponseApplier.cpp`
- Move repeated client response assignment into `ClientResponseApplier::apply`
- Replace repeated `responseBuffer`, `bytesSent`, `responseReady`, and `state = WRITING` blocks in `CgiManager`
- Add `ClientResponseApplier.cpp` to the Makefile

## Intent

This is a small mechanical refactor. It should not change response building, CGI lifecycle, cleanup, poll event handling, timeout handling, or fd management.

## Validation checklist

- [ ] `make fclean && make`
- [ ] second `make` does not relink unnecessarily
- [ ] regression baseline has no new differences
- [ ] stress tests produce no new failures
