### PR TITLE
Refactor CGI fd registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ NAME = webserv
 
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -g
+RM = rm -f
 
 SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiPipeIO.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))
@@ -25,10 +26,10 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp | $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) -MMD -MP -I$(INC_DIR) -c $< -o $@
 
 clean:
-	rm -rf $(OBJ_DIR)
+	$(RM) -r $(OBJ_DIR)
 
 fclean: clean
-	rm -rf $(NAME)
+	$(RM) $(NAME)
 
 re: fclean all
 

--- a/include/CgiFdRegistry.hpp
+++ b/include/CgiFdRegistry.hpp
@@ -1,0 +1,25 @@
+#ifndef CGI_FD_REGISTRY_HPP
+# define CGI_FD_REGISTRY_HPP
+
+# include "PollManager.hpp"
+# include <map>
+
+class CgiFdRegistry
+{
+	public:
+		CgiFdRegistry();
+		CgiFdRegistry(const CgiFdRegistry &other);
+		~CgiFdRegistry();
+		CgiFdRegistry &operator=(const CgiFdRegistry &other);
+
+		bool	contains(int cgiFd) const;
+		void	registerFd(int cgiFd, int clientFd);
+		void	unregisterFd(int cgiFd);
+		bool	getClientFd(int cgiFd, int &clientFd) const;
+		void	closeFd(int cgiFd, PollManager &pollManager);
+
+	private:
+		std::map<int, int> fdToClientFd;
+};
+
+#endif

--- a/include/CgiManager.hpp
+++ b/include/CgiManager.hpp
@@ -1,6 +1,7 @@
 #ifndef CGIMANAGER_HPP
 #define CGIMANAGER_HPP
 
+#include "CgiFdRegistry.hpp"
 #include "Client.hpp"
 #include "PollManager.hpp"
 #include "Config.hpp"
@@ -27,7 +28,7 @@ public:
     int startForClient(Client &client, const RouteConfig &route, const ServerConfig &server, PollManager &pollManager);
 
 private:
-	std::map<int, int> cgiFdToClientFd;
+	CgiFdRegistry fdRegistry;
 
 	void registerCgiFd(int cgiFd, int clientFd);
 	void unregisterCgiFd(int cgiFd);

--- a/include/CgiManager.hpp
+++ b/include/CgiManager.hpp
@@ -30,12 +30,6 @@ public:
 private:
 	CgiFdRegistry fdRegistry;
 
-	void registerCgiFd(int cgiFd, int clientFd);
-	void unregisterCgiFd(int cgiFd);
-	bool getClientFd(int cgiFd, int &clientFd) const;
-
-    void closeCgiFd(int fd, PollManager &pollManager);
-
     int writeToCgi(Client &client, PollManager &pollManager);
     int readFromCgi(Client &client, PollManager &pollManager);
     int checkFinished(Client &client);

--- a/src/CgiFdRegistry.cpp
+++ b/src/CgiFdRegistry.cpp
@@ -1,0 +1,54 @@
+#include "CgiFdRegistry.hpp"
+
+#include <unistd.h>
+
+CgiFdRegistry::CgiFdRegistry() {}
+
+CgiFdRegistry::CgiFdRegistry(const CgiFdRegistry &other)
+{
+	*this = other;
+}
+
+CgiFdRegistry::~CgiFdRegistry() {}
+
+CgiFdRegistry &CgiFdRegistry::operator=(const CgiFdRegistry &other)
+{
+	if (this != &other)
+		fdToClientFd = other.fdToClientFd;
+	return (*this);
+}
+
+bool	CgiFdRegistry::contains(int cgiFd) const
+{
+	return (fdToClientFd.find(cgiFd) != fdToClientFd.end());
+}
+
+void	CgiFdRegistry::registerFd(int cgiFd, int clientFd)
+{
+	fdToClientFd[cgiFd] = clientFd;
+}
+
+void	CgiFdRegistry::unregisterFd(int cgiFd)
+{
+	fdToClientFd.erase(cgiFd);
+}
+
+bool	CgiFdRegistry::getClientFd(int cgiFd, int &clientFd) const
+{
+	std::map<int, int>::const_iterator it;
+
+	it = fdToClientFd.find(cgiFd);
+	if (it == fdToClientFd.end())
+		return (false);
+	clientFd = it->second;
+	return (true);
+}
+
+void	CgiFdRegistry::closeFd(int cgiFd, PollManager &pollManager)
+{
+	if (cgiFd == -1)
+		return;
+	close(cgiFd);
+	pollManager.removeFd(cgiFd);
+	unregisterFd(cgiFd);
+}

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -63,32 +63,12 @@ bool CgiManager::isCgiFd(int fd) const
 	return (fdRegistry.contains(fd));
 }
 
-void CgiManager::registerCgiFd(int cgiFd, int clientFd)
-{
-	fdRegistry.registerFd(cgiFd, clientFd);
-}
-
-void CgiManager::unregisterCgiFd(int cgiFd)
-{
-	fdRegistry.unregisterFd(cgiFd);
-}
-
-bool CgiManager::getClientFd(int cgiFd, int &clientFd) const
-{
-	return (fdRegistry.getClientFd(cgiFd, clientFd));
-}
-
-void CgiManager::closeCgiFd(int fd, PollManager &pollManager)
-{
-	fdRegistry.closeFd(fd, pollManager);
-}
-
 void CgiManager::cleanup(Client &client, PollManager &pollManager)
 {
 	if (client.cgi.stdinFd != -1)
-		closeCgiFd(client.cgi.stdinFd, pollManager);
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
 	if (client.cgi.stdoutFd != -1)
-		closeCgiFd(client.cgi.stdoutFd, pollManager);
+		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
 	if (client.cgi.pid > 0)
 	{
 		kill(client.cgi.pid, SIGKILL);
@@ -104,7 +84,7 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 
 	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
-		closeCgiFd(client.cgi.stdinFd, pollManager);
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
 		client.cgi.stdinFd = -1;
 		client.cgi.stdinClosed = true;
 		return (0);
@@ -115,7 +95,7 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 
 	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
-		closeCgiFd(client.cgi.stdinFd, pollManager);
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
 		client.cgi.stdinFd = -1;
 		client.cgi.stdinClosed = true;
 	}
@@ -135,7 +115,7 @@ int CgiManager::readFromCgi(Client &client, PollManager &pollManager)
 		return (1);
 	if (result == CgiPipeIO::READ_EOF)
 	{
-		closeCgiFd(client.cgi.stdoutFd, pollManager);
+		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
 		client.cgi.stdoutFd = -1;
 		client.cgi.stdoutClosed = true;
 	}
@@ -252,12 +232,12 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	int clientFd;
 
 	fdRemoved = 0;
-	if (!getClientFd(cgiFd, clientFd))
+	if (!fdRegistry.getClientFd(cgiFd, clientFd))
 		return (1);
 	clientIt = clients.find(clientFd);
 	if (clientIt == clients.end())
 	{
-		closeCgiFd(cgiFd, pollManager);
+		fdRegistry.closeFd(cgiFd, pollManager);
 		return (1);
 	}
 
@@ -267,14 +247,14 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	{
 		if (cgiFd == client.cgi.stdinFd)
 		{
-			closeCgiFd(client.cgi.stdinFd, pollManager);
+			fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
 			client.cgi.stdinFd = -1;
 			client.cgi.stdinClosed = true;
 			fdRemoved = 1;
 		}
 		else if (cgiFd == client.cgi.stdoutFd)
 		{
-			closeCgiFd(client.cgi.stdoutFd, pollManager);
+			fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
 			client.cgi.stdoutFd = -1;
 			client.cgi.stdoutClosed = true;
 			fdRemoved = 1;
@@ -367,7 +347,7 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 	client.cgi.finished = false;
 	client.cgi.startTime = std::time(NULL);
 
-	registerCgiFd(client.cgi.stdoutFd, client.fd);
+	fdRegistry.registerFd(client.cgi.stdoutFd, client.fd);
 	pollManager.addFd(client.cgi.stdoutFd, POLLIN);
 
 	if (client.cgi.inputBuffer.empty())
@@ -379,7 +359,7 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 	}
 	else
 	{
-		registerCgiFd(client.cgi.stdinFd, client.fd);
+		fdRegistry.registerFd(client.cgi.stdinFd, client.fd);
 		pollManager.addFd(client.cgi.stdinFd, POLLOUT);
 		client.state = CGI_WRITING;
 	}

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -28,7 +28,7 @@ CgiManager::~CgiManager() {}
 CgiManager &CgiManager::operator=(const CgiManager &other)
 {
 	if (this != &other)
-		cgiFdToClientFd = other.cgiFdToClientFd;
+		fdRegistry = other.fdRegistry;
 	return (*this);
 }
 
@@ -60,38 +60,27 @@ static int setNonBlockingFd(int fd)
 
 bool CgiManager::isCgiFd(int fd) const
 {
-	return (cgiFdToClientFd.find(fd) != cgiFdToClientFd.end());
+	return (fdRegistry.contains(fd));
 }
 
 void CgiManager::registerCgiFd(int cgiFd, int clientFd)
 {
-	cgiFdToClientFd[cgiFd] = clientFd;
+	fdRegistry.registerFd(cgiFd, clientFd);
 }
 
 void CgiManager::unregisterCgiFd(int cgiFd)
 {
-	cgiFdToClientFd.erase(cgiFd);
+	fdRegistry.unregisterFd(cgiFd);
 }
 
 bool CgiManager::getClientFd(int cgiFd, int &clientFd) const
 {
-	std::map<int, int>::const_iterator it;
-
-	it = cgiFdToClientFd.find(cgiFd);
-	if (it == cgiFdToClientFd.end())
-		return (false);
-	clientFd = it->second;
-	return (true);
+	return (fdRegistry.getClientFd(cgiFd, clientFd));
 }
 
 void CgiManager::closeCgiFd(int fd, PollManager &pollManager)
 {
-	if (fd == -1)
-		return;
-
-	close(fd);
-	pollManager.removeFd(fd);
-	unregisterCgiFd(fd);
+	fdRegistry.closeFd(fd, pollManager);
 }
 
 void CgiManager::cleanup(Client &client, PollManager &pollManager)
@@ -268,9 +257,7 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	clientIt = clients.find(clientFd);
 	if (clientIt == clients.end())
 	{
-		close(cgiFd);
-		pollManager.removeFd(cgiFd);
-		unregisterCgiFd(cgiFd);
+		closeCgiFd(cgiFd, pollManager);
 		return (1);
 	}
 


### PR DESCRIPTION
## Summary

This PR extracts CGI fd-to-client mapping and CGI fd closing into a dedicated `CgiFdRegistry` helper.

## Changes

- Add `include/CgiFdRegistry.hpp`
- Add `src/CgiFdRegistry.cpp`
- Move CGI fd lookup/register/unregister logic out of `CgiManager`
- Move CGI fd close, poll removal, and unregister into `CgiFdRegistry::closeFd`
- Store a `CgiFdRegistry` member inside `CgiManager`
- Keep thin `CgiManager` wrappers for now to avoid changing higher-level CGI flow in the same PR
- Add `CgiFdRegistry.cpp` to the Makefile

## Intent

This prepares the architecture for extracting higher-level CGI completion and error handling later, without introducing callbacks from response helpers back into `CgiManager`.

This should not change CGI process startup, pipe I/O, response building, timeout handling, or client state transitions.
