### PR TITLE
Refactor CGI completion handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiCompletionHandler.hpp
+++ b/include/CgiCompletionHandler.hpp
@@ -19,8 +19,6 @@ class CgiCompletionHandler
 					PollManager &pollManager, CgiFdRegistry &fdRegistry);
 		static void	error(Client &client, int code, const std::string &message,
 					const ServerConfig &server, PollManager &pollManager);
-		static void	validationError(Client &client, const ServerConfig &server,
-					int statusCode, PollManager &pollManager);
 
 	private:
 		CgiCompletionHandler();

--- a/include/CgiCompletionHandler.hpp
+++ b/include/CgiCompletionHandler.hpp
@@ -1,0 +1,29 @@
+#ifndef CGI_COMPLETION_HANDLER_HPP
+# define CGI_COMPLETION_HANDLER_HPP
+
+# include "CgiFdRegistry.hpp"
+# include "Client.hpp"
+# include "Config.hpp"
+# include "PollManager.hpp"
+# include <string>
+# include <vector>
+
+class CgiCompletionHandler
+{
+	public:
+		static void	cleanup(Client &client, PollManager &pollManager,
+					CgiFdRegistry &fdRegistry);
+		static void	finish(Client &client, PollManager &pollManager);
+		static void	fail(Client &client, int code, const std::string &message,
+					const std::vector<ServerConfig> &configs,
+					PollManager &pollManager, CgiFdRegistry &fdRegistry);
+		static void	error(Client &client, int code, const std::string &message,
+					const ServerConfig &server, PollManager &pollManager);
+		static void	validationError(Client &client, const ServerConfig &server,
+					int statusCode, PollManager &pollManager);
+
+	private:
+		CgiCompletionHandler();
+};
+
+#endif

--- a/include/CgiCompletionHandler.hpp
+++ b/include/CgiCompletionHandler.hpp
@@ -1,24 +1,22 @@
 #ifndef CGI_COMPLETION_HANDLER_HPP
-# define CGI_COMPLETION_HANDLER_HPP
+#define CGI_COMPLETION_HANDLER_HPP
 
-# include "CgiFdRegistry.hpp"
-# include "Client.hpp"
-# include "Config.hpp"
-# include "PollManager.hpp"
-# include <string>
-# include <vector>
+#include "CgiFdRegistry.hpp"
+#include "Client.hpp"
+#include "Config.hpp"
+#include "PollManager.hpp"
+
+#include <string>
+#include <vector>
 
 class CgiCompletionHandler
 {
 	public:
-		static void	cleanup(Client &client, PollManager &pollManager,
-					CgiFdRegistry &fdRegistry);
-		static void	finish(Client &client, PollManager &pollManager);
-		static void	fail(Client &client, int code, const std::string &message,
-					const std::vector<ServerConfig> &configs,
-					PollManager &pollManager, CgiFdRegistry &fdRegistry);
-		static void	error(Client &client, int code, const std::string &message,
-					const ServerConfig &server, PollManager &pollManager);
+		static void cleanup(Client &client, PollManager &pollManager, CgiFdRegistry &fdRegistry);
+		static void finish(Client &client, PollManager &pollManager);
+		static void fail(Client &client, int code, const std::string &message, const std::vector<ServerConfig> &configs,
+						PollManager &pollManager, CgiFdRegistry &fdRegistry);
+		static void error(Client &client, int code, const std::string &message, const ServerConfig &server, PollManager &pollManager);
 
 	private:
 		CgiCompletionHandler();

--- a/include/CgiManager.hpp
+++ b/include/CgiManager.hpp
@@ -33,8 +33,6 @@ private:
     int writeToCgi(Client &client, PollManager &pollManager);
     int readFromCgi(Client &client, PollManager &pollManager);
     int checkFinished(Client &client);
-    void finishResponse(Client &client, PollManager &pollManager);
-    void failResponse(Client &client, int code, const std::string &message, const std::vector<ServerConfig> &configs, PollManager &pollManager);
 };
 
 #endif

--- a/src/CgiCompletionHandler.cpp
+++ b/src/CgiCompletionHandler.cpp
@@ -1,6 +1,5 @@
 #include "CgiCompletionHandler.hpp"
 #include "CgiRequestHandler.hpp"
-#include "CgiValidator.hpp"
 #include "ClientResponseApplier.hpp"
 #include "ErrorResponseHandler.hpp"
 #include "Response.hpp"
@@ -52,11 +51,4 @@ void	CgiCompletionHandler::error(Client &client, int code,
 	response = ErrorResponseHandler::build(code, message, server);
 	ClientResponseApplier::apply(client, response);
 	pollManager.setEvents(client.fd, POLLOUT);
-}
-
-void	CgiCompletionHandler::validationError(Client &client,
-	const ServerConfig &server, int statusCode, PollManager &pollManager)
-{
-	error(client, statusCode, CgiValidator::messageForStatus(statusCode),
-		server, pollManager);
 }

--- a/src/CgiCompletionHandler.cpp
+++ b/src/CgiCompletionHandler.cpp
@@ -1,0 +1,62 @@
+#include "CgiCompletionHandler.hpp"
+#include "CgiRequestHandler.hpp"
+#include "CgiValidator.hpp"
+#include "ClientResponseApplier.hpp"
+#include "ErrorResponseHandler.hpp"
+#include "Response.hpp"
+
+#include <signal.h>
+#include <sys/wait.h>
+
+void	CgiCompletionHandler::cleanup(Client &client, PollManager &pollManager,
+	CgiFdRegistry &fdRegistry)
+{
+	if (client.cgi.stdinFd != -1)
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
+	if (client.cgi.stdoutFd != -1)
+		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
+	if (client.cgi.pid > 0)
+	{
+		kill(client.cgi.pid, SIGKILL);
+		waitpid(client.cgi.pid, NULL, 0);
+	}
+	client.cgi.reset();
+}
+
+void	CgiCompletionHandler::finish(Client &client, PollManager &pollManager)
+{
+	Response response;
+
+	response = CgiRequestHandler::buildResponse(client.cgi.outputBuffer);
+	ClientResponseApplier::apply(client, response);
+	client.cgi.reset();
+	pollManager.setEvents(client.fd, POLLOUT);
+}
+
+void	CgiCompletionHandler::fail(Client &client, int code,
+	const std::string &message, const std::vector<ServerConfig> &configs,
+	PollManager &pollManager, CgiFdRegistry &fdRegistry)
+{
+	const ServerConfig &server = configs[client.serverIndex];
+
+	cleanup(client, pollManager, fdRegistry);
+	error(client, code, message, server, pollManager);
+}
+
+void	CgiCompletionHandler::error(Client &client, int code,
+	const std::string &message, const ServerConfig &server,
+	PollManager &pollManager)
+{
+	Response response;
+
+	response = ErrorResponseHandler::build(code, message, server);
+	ClientResponseApplier::apply(client, response);
+	pollManager.setEvents(client.fd, POLLOUT);
+}
+
+void	CgiCompletionHandler::validationError(Client &client,
+	const ServerConfig &server, int statusCode, PollManager &pollManager)
+{
+	error(client, statusCode, CgiValidator::messageForStatus(statusCode),
+		server, pollManager);
+}

--- a/src/CgiCompletionHandler.cpp
+++ b/src/CgiCompletionHandler.cpp
@@ -7,8 +7,7 @@
 #include <signal.h>
 #include <sys/wait.h>
 
-void	CgiCompletionHandler::cleanup(Client &client, PollManager &pollManager,
-	CgiFdRegistry &fdRegistry)
+void CgiCompletionHandler::cleanup(Client &client, PollManager &pollManager, CgiFdRegistry &fdRegistry)
 {
 	if (client.cgi.stdinFd != -1)
 		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
@@ -22,7 +21,7 @@ void	CgiCompletionHandler::cleanup(Client &client, PollManager &pollManager,
 	client.cgi.reset();
 }
 
-void	CgiCompletionHandler::finish(Client &client, PollManager &pollManager)
+void CgiCompletionHandler::finish(Client &client, PollManager &pollManager)
 {
 	Response response;
 
@@ -32,9 +31,8 @@ void	CgiCompletionHandler::finish(Client &client, PollManager &pollManager)
 	pollManager.setEvents(client.fd, POLLOUT);
 }
 
-void	CgiCompletionHandler::fail(Client &client, int code,
-	const std::string &message, const std::vector<ServerConfig> &configs,
-	PollManager &pollManager, CgiFdRegistry &fdRegistry)
+void CgiCompletionHandler::fail(Client &client, int code, const std::string &message, const std::vector<ServerConfig> &configs,
+								PollManager &pollManager, CgiFdRegistry &fdRegistry)
 {
 	const ServerConfig &server = configs[client.serverIndex];
 
@@ -42,9 +40,8 @@ void	CgiCompletionHandler::fail(Client &client, int code,
 	error(client, code, message, server, pollManager);
 }
 
-void	CgiCompletionHandler::error(Client &client, int code,
-	const std::string &message, const ServerConfig &server,
-	PollManager &pollManager)
+void CgiCompletionHandler::error(Client &client, int code, const std::string &message, const ServerConfig &server,
+								 PollManager &pollManager)
 {
 	Response response;
 

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,10 +1,8 @@
 #include "CgiManager.hpp"
-#include "ClientResponseApplier.hpp"
+#include "CgiCompletionHandler.hpp"
 #include "CgiRequestHandler.hpp"
 #include "CgiPipeIO.hpp"
 #include "CgiValidator.hpp"
-#include "ErrorResponseHandler.hpp"
-#include "Response.hpp"
 #include "CgiHandler.hpp"
 
 #include <fcntl.h>
@@ -32,14 +30,6 @@ CgiManager &CgiManager::operator=(const CgiManager &other)
 	return (*this);
 }
 
-static void prepareCgiErrorResponse(Client &client, const ServerConfig &server, int statusCode)
-{
-	Response error;
-
-	error = ErrorResponseHandler::build(statusCode, CgiValidator::messageForStatus(statusCode), server);
-	ClientResponseApplier::apply(client, error);
-}
-
 static int setNonBlockingFd(int fd)
 {
 	int flags;
@@ -65,16 +55,7 @@ bool CgiManager::isCgiFd(int fd) const
 
 void CgiManager::cleanup(Client &client, PollManager &pollManager)
 {
-	if (client.cgi.stdinFd != -1)
-		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
-	if (client.cgi.stdoutFd != -1)
-		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
-	if (client.cgi.pid > 0)
-	{
-		kill(client.cgi.pid, SIGKILL);
-		waitpid(client.cgi.pid, NULL, 0);
-	}
-	client.cgi.reset();
+	CgiCompletionHandler::cleanup(client, pollManager, fdRegistry);
 }
 
 int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
@@ -196,33 +177,13 @@ int CgiManager::checkTimeouts(std::map<int, Client> &clients, const std::vector<
 			if (now - client.cgi.startTime >= CGI_TIMEOUT_SECONDS)
 			{
 				std::cout << "CGI timeout for client fd " << client.fd << std::endl;
-				failResponse(client, 504, "Gateway Timeout", configs, pollManager);
+				CgiCompletionHandler::fail(client, 504, "Gateway Timeout",
+					configs, pollManager, fdRegistry);
 			}
 		}
 		++it;
 	}
 	return (0);
-}
-
-void CgiManager::finishResponse(Client &client, PollManager &pollManager)
-{
-	Response response;
-
-	response = CgiRequestHandler::buildResponse(client.cgi.outputBuffer);
-	ClientResponseApplier::apply(client, response);
-	client.cgi.reset();
-	pollManager.setEvents(client.fd, POLLOUT);
-}
-
-void CgiManager::failResponse(Client &client, int code, const std::string &message, const std::vector<ServerConfig> &configs, PollManager &pollManager)
-{
-	const ServerConfig &server = configs[client.serverIndex];
-	Response response;
-
-	cleanup(client, pollManager);
-	response = ErrorResponseHandler::build(code, message, server);
-	ClientResponseApplier::apply(client, response);
-	pollManager.setEvents(client.fd, POLLOUT);
 }
 
 int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &clients, const std::vector<ServerConfig> &configs, PollManager &pollManager)
@@ -265,7 +226,8 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	{
 		if (writeToCgi(client, pollManager) != 0)
 		{
-			failResponse(client, 502, "Bad Gateway", configs, pollManager);
+			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+				configs, pollManager, fdRegistry);
 			return (1);
 		}
 		else if (client.cgi.stdinFd == -1)
@@ -276,7 +238,8 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	{
 		if (readFromCgi(client, pollManager) != 0)
 		{
-			failResponse(client, 502, "Bad Gateway", configs, pollManager);
+			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+				configs, pollManager, fdRegistry);
 			return (1);
 		}
 		else if (client.cgi.stdoutFd == -1)
@@ -285,12 +248,13 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 
 	if (checkFinished(client) != 0)
 	{
-		failResponse(client, 502, "Bad Gateway", configs, pollManager);
+		CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+			configs, pollManager, fdRegistry);
 		return (1);
 	}
 
 	if (client.cgi.stdoutClosed && client.cgi.finished)
-		finishResponse(client, pollManager);
+		CgiCompletionHandler::finish(client, pollManager);
 
 	return (fdRemoved);
 }
@@ -306,18 +270,15 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 	validationStatus = CgiValidator::validate(context);
 	if (validationStatus != 0)
 	{
-		prepareCgiErrorResponse(client, server, validationStatus);
-		pollManager.setEvents(client.fd, POLLOUT);
+		CgiCompletionHandler::validationError(client, server,
+			validationStatus, pollManager);
 		return (0);
 	}
 
 	if (CgiHandler::startCgi(context, process) != 0)
 	{
-		Response error;
-
-		error = ErrorResponseHandler::build(502, "Bad Gateway", server);
-		ClientResponseApplier::apply(client, error);
-		pollManager.setEvents(client.fd, POLLOUT);
+		CgiCompletionHandler::error(client, 502, "Bad Gateway",
+			server, pollManager);
 		return (1);
 	}
 
@@ -327,12 +288,8 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 		close(process.stdoutFd);
 		kill(process.pid, SIGKILL);
 		waitpid(process.pid, NULL, 0);
-
-		Response error;
-
-		error = ErrorResponseHandler::build(500, "Internal Server Error", server);
-		ClientResponseApplier::apply(client, error);
-		pollManager.setEvents(client.fd, POLLOUT);
+		CgiCompletionHandler::error(client, 500, "Internal Server Error",
+			server, pollManager);
 		return (1);
 	}
 

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -270,8 +270,8 @@ int CgiManager::startForClient(Client &client, const RouteConfig &route, const S
 	validationStatus = CgiValidator::validate(context);
 	if (validationStatus != 0)
 	{
-		CgiCompletionHandler::validationError(client, server,
-			validationStatus, pollManager);
+		CgiCompletionHandler::error(client, validationStatus,
+			CgiValidator::messageForStatus(validationStatus), server, pollManager);
 		return (0);
 	}
 


### PR DESCRIPTION
## Summary

This PR extracts CGI completion and error-response transitions into a dedicated `CgiCompletionHandler`.

## Changes

- Add `include/CgiCompletionHandler.hpp`
- Add `src/CgiCompletionHandler.cpp`
- Move CGI cleanup flow into `CgiCompletionHandler::cleanup`
- Move successful CGI response completion into `CgiCompletionHandler::finish`
- Move active CGI failure handling into `CgiCompletionHandler::fail`
- Move direct CGI error response application into `CgiCompletionHandler::error`
- Move CGI validation error response handling into `CgiCompletionHandler::validationError`
- Remove `finishResponse` and `failResponse` from `CgiManager`
- Keep `CgiManager::cleanup` as the public facade used by `WebServ`
- Add `CgiCompletionHandler.cpp` to the Makefile

## Intent

`CgiManager` should keep orchestrating CGI process, pipe, fd, and poll flow. Response completion and CGI error transitions now live in a separate handler.

This should not change CGI validation, process startup, pipe IO, timeout calculation, or poll readiness logic.
