### PR TITLE
Feat/directory index resolution

### DIFF
--- a/configs/default.conf
+++ b/configs/default.conf
@@ -32,6 +32,13 @@ server {
         upload_enable off;
     }
 
+    location /server-index-test {
+        methods GET;
+        root ./www/static/server-index-test;
+        autoindex off;
+        upload_enable off;
+    }
+
     location /uploads {
         methods GET POST DELETE;
         root ./www/uploads;

--- a/docs/autoindex-tests.md
+++ b/docs/autoindex-tests.md
@@ -56,6 +56,9 @@ printf "world\n" > www/static/listing-test/b.txt
 mkdir -p www/static/with-index
 printf "<h1>Index works</h1>" > www/static/with-index/index.html
 
+mkdir -p www/static/server-index-test
+printf "<h1>Server index fallback works</h1>\n" > www/static/server-index-test/index.html
+
 mkdir -p www/static/sort-test/assets
 mkdir -p www/static/sort-test/css
 mkdir -p www/static/sort-test/scripts
@@ -214,6 +217,28 @@ Body:
 ```
 
 Purpose: `index.html` has priority over autoindex.
+
+---
+
+## 7bis. Test: server index fallback when location has no index
+
+```bash
+curl -i http://localhost:8080/server-index-test/
+```
+
+Expected:
+
+```http
+HTTP/1.1 200 OK
+```
+
+Body:
+
+```html
+<h1>Server index fallback works</h1>
+```
+
+Purpose: when a location does not define `index`, the server-level `index` (`index.html`) is used for directory requests.
 
 ---
 
@@ -585,6 +610,7 @@ curl -i http://localhost:8080/no-such-file
 curl -i http://localhost:8080/static/
 curl -i http://localhost:8080/static/listing-test/
 curl -i http://localhost:8080/static/with-index/
+curl -i http://localhost:8080/server-index-test/
 curl -i http://localhost:8080/static/listing-test/a.txt
 curl -i http://localhost:8080/uploads/
 curl -i http://localhost:8080/static/not-found/
@@ -623,6 +649,7 @@ Expected summary:
 | `/static/`                          |        `200 OK` | Autoindex enabled                                           |
 | `/static/listing-test/`             |        `200 OK` | Nested autoindex                                            |
 | `/static/with-index/`               |        `200 OK` | Index file priority                                         |
+| `/server-index-test/`               |        `200 OK` | Server-level index fallback                                 |
 | `/static/listing-test/a.txt`        |        `200 OK` | Static file serving                                         |
 | `/uploads/`                         | `403 Forbidden` | Autoindex disabled                                          |
 | `/static/not-found/`                | `404 Not Found` | Missing directory                                           |

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -7,7 +7,7 @@
 
 #include "utils.hpp"
 
-Response::Response () {}
+Response::Response () : statusCode(0) {}
 
 Response::~Response () {}
 

--- a/src/StaticFileHandler.cpp
+++ b/src/StaticFileHandler.cpp
@@ -248,14 +248,11 @@ static Response tryServeConfiguredIndexFiles(const std::string &fullPath,
 
 static Response handleDirectoryRequest(const std::string &requestPath, const std::string &fullPath, const RouteConfig &route, const ServerConfig &server)
 {
-	std::string indexPath;
+	Response response;
 
-	if (!route.index.empty())
-	{
-		indexPath = PathUtils::join(fullPath, route.index);
-		if (isRegularFile(indexPath))
-			return (buildFileResponse(indexPath));
-	}
+	response = tryServeConfiguredIndexFiles(fullPath, route, server);
+	if (response.getStatusCode() != 0)
+		return (response);
 	if (route.autoindex)
 		return (buildAutoindexResponse(requestPath, fullPath, server));
 	return (ErrorResponseHandler::build(403, "Forbidden", server));

--- a/src/StaticFileHandler.cpp
+++ b/src/StaticFileHandler.cpp
@@ -233,6 +233,19 @@ static Response tryServeDirectoryIndex(const std::string &fullPath,
 	return (buildFileResponse(indexPath));
 }
 
+static Response tryServeConfiguredIndexFiles(const std::string &fullPath,
+	const RouteConfig &route, const ServerConfig &server)
+{
+	Response response;
+	response = tryServeDirectoryIndex(fullPath, route.index);
+	if (response.getStatusCode() != 0)
+		return (response);
+	response = tryServeDirectoryIndex(fullPath, server.index);
+	if (response.getStatusCode() != 0)
+		return (response);
+	return (Response());
+}
+
 static Response handleDirectoryRequest(const std::string &requestPath, const std::string &fullPath, const RouteConfig &route, const ServerConfig &server)
 {
 	std::string indexPath;

--- a/src/StaticFileHandler.cpp
+++ b/src/StaticFileHandler.cpp
@@ -221,6 +221,18 @@ static Response buildAutoindexResponse(const std::string &requestPath, const std
 	return (response);
 }
 
+static Response tryServeDirectoryIndex(const std::string &fullPath,
+	const std::string &indexName)
+{
+	std::string indexPath;
+	if (indexName.empty())
+		return (Response());
+	indexPath = PathUtils::join(fullPath, indexName);
+	if (!isRegularFile(indexPath))
+		return (Response());
+	return (buildFileResponse(indexPath));
+}
+
 static Response handleDirectoryRequest(const std::string &requestPath, const std::string &fullPath, const RouteConfig &route, const ServerConfig &server)
 {
 	std::string indexPath;

--- a/www/static/server-index-test/index.html
+++ b/www/static/server-index-test/index.html
@@ -1,0 +1,1 @@
+<h1>Server index fallback works</h1>


### PR DESCRIPTION
### Summary of the PR

## What changed : 
Directory index resolution (`StaticFileHandler.cpp`)
When the resolved path on disk is a directory, the server now :
- tries the location index (`route.index`) if it is configured
- if that file doesn't exist it tries the server index (`server.index`) (PS: this was missing before)
- serves the first index file that actually exists on disk
- if no index file is found : serves an autoindex listing if autoindex is on, otherwise it returns `403 Forbidden`

**!!** Wasn't included in the subtasks but I also added a small fix in `Response.cpp` (empty `Response` objects are now created with `statusCode = 0`)
-> this was needed because the new helpers use an empty response to mean “no index file found yet”. Without initializing `statusCode`, the server sometimes sent a 'broken' HTTP response on paths like `/static/` or `/uploads/`

## Tests
I added manual tests in `docs/autoindex-tests.md` section 7bis
+ updated regression checklist and expected summary table
+  added a new route `/server-index-test` for the fallback test in `configs/default.conf`

Existing behavior was checked and still works
