### PR TITLE
Refactor CGI startup handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiTimeoutHandler.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiStartupHandler.hpp
+++ b/include/CgiStartupHandler.hpp
@@ -1,0 +1,27 @@
+#ifndef CGI_STARTUP_HANDLER_HPP
+# define CGI_STARTUP_HANDLER_HPP
+
+# include "CgiFdRegistry.hpp"
+# include "CgiHandler.hpp"
+# include "Client.hpp"
+# include "Config.hpp"
+# include "PollManager.hpp"
+
+class CgiStartupHandler
+{
+	public:
+		static int	startForClient(Client &client, const RouteConfig &route,
+					const ServerConfig &server, PollManager &pollManager,
+					CgiFdRegistry &fdRegistry);
+
+	private:
+		CgiStartupHandler();
+		static int	setNonBlockingFd(int fd);
+		static void	cleanupFailedProcess(CgiProcess &process);
+		static void	initSession(Client &client, const CgiContext &context,
+					const CgiProcess &process);
+		static void	registerProcessFds(Client &client, PollManager &pollManager,
+					CgiFdRegistry &fdRegistry);
+};
+
+#endif

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,19 +1,10 @@
 #include "CgiManager.hpp"
 #include "CgiCompletionHandler.hpp"
-#include "CgiRequestHandler.hpp"
 #include "CgiPipeIO.hpp"
+#include "CgiStartupHandler.hpp"
 #include "CgiTimeoutHandler.hpp"
-#include "CgiValidator.hpp"
-#include "CgiHandler.hpp"
 
-#include <fcntl.h>
-#include <ctime>
-#include <iostream>
-#include <signal.h>
-#include <unistd.h>
-#include <cerrno>
 #include <sys/wait.h>
-#include <cstring>
 
 CgiManager::CgiManager() {}
 
@@ -31,24 +22,6 @@ CgiManager &CgiManager::operator=(const CgiManager &other)
 	return (*this);
 }
 
-static int setNonBlockingFd(int fd)
-{
-	int flags;
-
-	flags = fcntl(fd, F_GETFL, 0);
-	if (flags == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	return (0);
-}
-
 bool CgiManager::isCgiFd(int fd) const
 {
 	return (fdRegistry.contains(fd));
@@ -63,7 +36,6 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 {
 	if (client.cgi.stdinFd == -1 || client.cgi.stdinClosed)
 		return (0);
-
 	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
 		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
@@ -71,17 +43,14 @@ int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
 		client.cgi.stdinClosed = true;
 		return (0);
 	}
-
 	if (CgiPipeIO::writeToStdin(client.cgi) != 0)
 		return (1);
-
 	if (CgiPipeIO::hasInputFinished(client.cgi))
 	{
 		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
 		client.cgi.stdinFd = -1;
 		client.cgi.stdinClosed = true;
 	}
-
 	return (0);
 }
 
@@ -91,7 +60,6 @@ int CgiManager::readFromCgi(Client &client, PollManager &pollManager)
 
 	if (client.cgi.stdoutFd == -1 || client.cgi.stdoutClosed)
 		return (0);
-
 	result = CgiPipeIO::readFromStdout(client.cgi);
 	if (result == CgiPipeIO::READ_ERROR)
 		return (1);
@@ -111,19 +79,15 @@ int CgiManager::checkFinished(Client &client)
 
 	if (client.cgi.pid <= 0)
 		return (0);
-
 	result = waitpid(client.cgi.pid, &status, WNOHANG);
 	if (result == 0)
 		return (0);
 	if (result != client.cgi.pid)
 		return (1);
-
 	client.cgi.pid = -1;
 	client.cgi.finished = true;
-
 	if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
 		return (0);
-
 	return (1);
 }
 
@@ -132,13 +96,16 @@ int CgiManager::getPollTimeoutMs(const std::map<int, Client> &clients) const
 	return (CgiTimeoutHandler::getPollTimeoutMs(clients));
 }
 
-int CgiManager::checkTimeouts(std::map<int, Client> &clients, const std::vector<ServerConfig> &configs, PollManager &pollManager)
+int CgiManager::checkTimeouts(std::map<int, Client> &clients,
+	const std::vector<ServerConfig> &configs, PollManager &pollManager)
 {
 	return (CgiTimeoutHandler::handleTimeouts(clients, configs,
 		pollManager, fdRegistry));
 }
 
-int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &clients, const std::vector<ServerConfig> &configs, PollManager &pollManager)
+int CgiManager::handleEvent(int cgiFd, short revents,
+	std::map<int, Client> &clients,
+	const std::vector<ServerConfig> &configs, PollManager &pollManager)
 {
 	std::map<int, Client>::iterator clientIt;
 	int fdRemoved;
@@ -155,7 +122,6 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 	}
 
 	Client &client = clientIt->second;
-
 	if (revents & (POLLERR | POLLHUP | POLLNVAL))
 	{
 		if (cgiFd == client.cgi.stdinFd)
@@ -173,7 +139,6 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 			fdRemoved = 1;
 		}
 	}
-
 	if ((revents & POLLOUT) && cgiFd == client.cgi.stdinFd)
 	{
 		if (writeToCgi(client, pollManager) != 0)
@@ -185,7 +150,6 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 		else if (client.cgi.stdinFd == -1)
 			fdRemoved = 1;
 	}
-
 	if ((revents & POLLIN) && cgiFd == client.cgi.stdoutFd)
 	{
 		if (readFromCgi(client, pollManager) != 0)
@@ -197,82 +161,20 @@ int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &cli
 		else if (client.cgi.stdoutFd == -1)
 			fdRemoved = 1;
 	}
-
 	if (checkFinished(client) != 0)
 	{
 		CgiCompletionHandler::fail(client, 502, "Bad Gateway",
 			configs, pollManager, fdRegistry);
 		return (1);
 	}
-
 	if (client.cgi.stdoutClosed && client.cgi.finished)
 		CgiCompletionHandler::finish(client, pollManager);
-
 	return (fdRemoved);
 }
 
-int CgiManager::startForClient(Client &client, const RouteConfig &route, const ServerConfig &server, PollManager &pollManager)
+int CgiManager::startForClient(Client &client, const RouteConfig &route,
+	const ServerConfig &server, PollManager &pollManager)
 {
-	CgiContext context;
-	CgiProcess process;
-	int validationStatus;
-
-	context = CgiRequestHandler::buildContext(client.request, route, server, client.getRemoteAddr());
-
-	validationStatus = CgiValidator::validate(context);
-	if (validationStatus != 0)
-	{
-		CgiCompletionHandler::error(client, validationStatus,
-			CgiValidator::messageForStatus(validationStatus), server, pollManager);
-		return (0);
-	}
-
-	if (CgiHandler::startCgi(context, process) != 0)
-	{
-		CgiCompletionHandler::error(client, 502, "Bad Gateway",
-			server, pollManager);
-		return (1);
-	}
-
-	if (setNonBlockingFd(process.stdinFd) || setNonBlockingFd(process.stdoutFd))
-	{
-		close(process.stdinFd);
-		close(process.stdoutFd);
-		kill(process.pid, SIGKILL);
-		waitpid(process.pid, NULL, 0);
-		CgiCompletionHandler::error(client, 500, "Internal Server Error",
-			server, pollManager);
-		return (1);
-	}
-
-	client.cgi.pid = process.pid;
-	client.cgi.stdinFd = process.stdinFd;
-	client.cgi.stdoutFd = process.stdoutFd;
-	client.cgi.inputBuffer = context.requestBody;
-	client.cgi.inputSent = 0;
-	client.cgi.outputBuffer.clear();
-	client.cgi.stdinClosed = false;
-	client.cgi.stdoutClosed = false;
-	client.cgi.finished = false;
-	client.cgi.startTime = std::time(NULL);
-
-	fdRegistry.registerFd(client.cgi.stdoutFd, client.fd);
-	pollManager.addFd(client.cgi.stdoutFd, POLLIN);
-
-	if (client.cgi.inputBuffer.empty())
-	{
-		close(client.cgi.stdinFd);
-		client.cgi.stdinFd = -1;
-		client.cgi.stdinClosed = true;
-		client.state = CGI_READING;
-	}
-	else
-	{
-		fdRegistry.registerFd(client.cgi.stdinFd, client.fd);
-		pollManager.addFd(client.cgi.stdinFd, POLLOUT);
-		client.state = CGI_WRITING;
-	}
-
-	pollManager.setEvents(client.fd, POLLIN);
-	return (0);
+	return (CgiStartupHandler::startForClient(client, route, server,
+		pollManager, fdRegistry));
 }

--- a/src/CgiStartupHandler.cpp
+++ b/src/CgiStartupHandler.cpp
@@ -1,0 +1,120 @@
+#include "CgiStartupHandler.hpp"
+#include "CgiCompletionHandler.hpp"
+#include "CgiRequestHandler.hpp"
+#include "CgiValidator.hpp"
+
+#include <cerrno>
+#include <ctime>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int	CgiStartupHandler::startForClient(Client &client,
+	const RouteConfig &route, const ServerConfig &server,
+	PollManager &pollManager, CgiFdRegistry &fdRegistry)
+{
+	CgiContext context;
+	CgiProcess process;
+	int validationStatus;
+
+	context = CgiRequestHandler::buildContext(client.request, route, server,
+		client.getRemoteAddr());
+
+	validationStatus = CgiValidator::validate(context);
+	if (validationStatus != 0)
+	{
+		CgiCompletionHandler::error(client, validationStatus,
+			CgiValidator::messageForStatus(validationStatus), server, pollManager);
+		return (0);
+	}
+
+	if (CgiHandler::startCgi(context, process) != 0)
+	{
+		CgiCompletionHandler::error(client, 502, "Bad Gateway",
+			server, pollManager);
+		return (1);
+	}
+
+	if (setNonBlockingFd(process.stdinFd) || setNonBlockingFd(process.stdoutFd))
+	{
+		cleanupFailedProcess(process);
+		CgiCompletionHandler::error(client, 500, "Internal Server Error",
+			server, pollManager);
+		return (1);
+	}
+
+	initSession(client, context, process);
+	registerProcessFds(client, pollManager, fdRegistry);
+	pollManager.setEvents(client.fd, POLLIN);
+	return (0);
+}
+
+int	CgiStartupHandler::setNonBlockingFd(int fd)
+{
+	int flags;
+
+	flags = fcntl(fd, F_GETFL, 0);
+	if (flags == -1)
+	{
+		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		return (1);
+	}
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+	{
+		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		return (1);
+	}
+	return (0);
+}
+
+void	CgiStartupHandler::cleanupFailedProcess(CgiProcess &process)
+{
+	if (process.stdinFd != -1)
+		close(process.stdinFd);
+	if (process.stdoutFd != -1)
+		close(process.stdoutFd);
+	if (process.pid > 0)
+	{
+		kill(process.pid, SIGKILL);
+		waitpid(process.pid, NULL, 0);
+	}
+}
+
+void	CgiStartupHandler::initSession(Client &client,
+	const CgiContext &context, const CgiProcess &process)
+{
+	client.cgi.pid = process.pid;
+	client.cgi.stdinFd = process.stdinFd;
+	client.cgi.stdoutFd = process.stdoutFd;
+	client.cgi.inputBuffer = context.requestBody;
+	client.cgi.inputSent = 0;
+	client.cgi.outputBuffer.clear();
+	client.cgi.stdinClosed = false;
+	client.cgi.stdoutClosed = false;
+	client.cgi.finished = false;
+	client.cgi.startTime = std::time(NULL);
+}
+
+void	CgiStartupHandler::registerProcessFds(Client &client,
+	PollManager &pollManager, CgiFdRegistry &fdRegistry)
+{
+	fdRegistry.registerFd(client.cgi.stdoutFd, client.fd);
+	pollManager.addFd(client.cgi.stdoutFd, POLLIN);
+
+	if (client.cgi.inputBuffer.empty())
+	{
+		close(client.cgi.stdinFd);
+		client.cgi.stdinFd = -1;
+		client.cgi.stdinClosed = true;
+		client.state = CGI_READING;
+	}
+	else
+	{
+		fdRegistry.registerFd(client.cgi.stdinFd, client.fd);
+		pollManager.addFd(client.cgi.stdinFd, POLLOUT);
+		client.state = CGI_WRITING;
+	}
+}


### PR DESCRIPTION
## Summary

This PR extracts CGI startup flow from `CgiManager` into a dedicated `CgiStartupHandler`.

## Changes

- Add `include/CgiStartupHandler.hpp`
- Add `src/CgiStartupHandler.cpp`
- Move CGI context creation into `CgiStartupHandler::startForClient`
- Move CGI validation and validation error response handling into startup handler
- Move `CgiHandler::startCgi` startup flow into startup handler
- Move pipe fd non-blocking setup into startup handler
- Move failed-process cleanup on startup setup failure into startup handler
- Move `client.cgi` session initialization into startup handler
- Move CGI fd registration and initial CGI state selection into startup handler
- Keep `CgiManager::startForClient` as the public facade used by the rest of the server
- Add `CgiStartupHandler.cpp` to the Makefile

## Intent

`CgiStartupHandler` owns CGI startup orchestration, matching the architecture already used by `CgiCompletionHandler` and `CgiTimeoutHandler`.

`CgiManager` remains responsible for CGI event orchestration and as the public CGI facade, while startup-specific details are isolated in the dedicated handler.

This should not change CGI validation behavior, startup errors, non-blocking setup, fd registration, client CGI state initialization, or poll event setup.
