### PR TITLE
Refactor CGI event handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/CgiEventHandler.hpp
+++ b/include/CgiEventHandler.hpp
@@ -1,0 +1,28 @@
+#ifndef CGI_EVENT_HANDLER_HPP
+# define CGI_EVENT_HANDLER_HPP
+
+# include "CgiFdRegistry.hpp"
+# include "Client.hpp"
+# include "Config.hpp"
+# include "PollManager.hpp"
+# include <map>
+# include <vector>
+
+class CgiEventHandler
+{
+	public:
+		static int	handleEvent(int cgiFd, short revents,
+					std::map<int, Client> &clients,
+					const std::vector<ServerConfig> &configs,
+					PollManager &pollManager, CgiFdRegistry &fdRegistry);
+
+	private:
+		CgiEventHandler();
+		static int	writeToCgi(Client &client, PollManager &pollManager,
+					CgiFdRegistry &fdRegistry);
+		static int	readFromCgi(Client &client, PollManager &pollManager,
+					CgiFdRegistry &fdRegistry);
+		static int	checkFinished(Client &client);
+};
+
+#endif

--- a/include/CgiManager.hpp
+++ b/include/CgiManager.hpp
@@ -27,10 +27,6 @@ public:
 
 private:
 	CgiFdRegistry fdRegistry;
-
-    int writeToCgi(Client &client, PollManager &pollManager);
-    int readFromCgi(Client &client, PollManager &pollManager);
-    int checkFinished(Client &client);
 };
 
 #endif

--- a/src/CgiEventHandler.cpp
+++ b/src/CgiEventHandler.cpp
@@ -1,0 +1,136 @@
+#include "CgiEventHandler.hpp"
+#include "CgiCompletionHandler.hpp"
+#include "CgiPipeIO.hpp"
+
+#include <sys/wait.h>
+
+int	CgiEventHandler::handleEvent(int cgiFd, short revents,
+	std::map<int, Client> &clients,
+	const std::vector<ServerConfig> &configs, PollManager &pollManager,
+	CgiFdRegistry &fdRegistry)
+{
+	std::map<int, Client>::iterator clientIt;
+	int fdRemoved;
+	int clientFd;
+
+	fdRemoved = 0;
+	if (!fdRegistry.getClientFd(cgiFd, clientFd))
+		return (1);
+	clientIt = clients.find(clientFd);
+	if (clientIt == clients.end())
+	{
+		fdRegistry.closeFd(cgiFd, pollManager);
+		return (1);
+	}
+
+	Client &client = clientIt->second;
+	if (revents & (POLLERR | POLLHUP | POLLNVAL))
+	{
+		if (cgiFd == client.cgi.stdinFd)
+		{
+			fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
+			client.cgi.stdinFd = -1;
+			client.cgi.stdinClosed = true;
+			fdRemoved = 1;
+		}
+		else if (cgiFd == client.cgi.stdoutFd)
+		{
+			fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
+			client.cgi.stdoutFd = -1;
+			client.cgi.stdoutClosed = true;
+			fdRemoved = 1;
+		}
+	}
+	if ((revents & POLLOUT) && cgiFd == client.cgi.stdinFd)
+	{
+		if (writeToCgi(client, pollManager, fdRegistry) != 0)
+		{
+			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+				configs, pollManager, fdRegistry);
+			return (1);
+		}
+		else if (client.cgi.stdinFd == -1)
+			fdRemoved = 1;
+	}
+	if ((revents & POLLIN) && cgiFd == client.cgi.stdoutFd)
+	{
+		if (readFromCgi(client, pollManager, fdRegistry) != 0)
+		{
+			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+				configs, pollManager, fdRegistry);
+			return (1);
+		}
+		else if (client.cgi.stdoutFd == -1)
+			fdRemoved = 1;
+	}
+	if (checkFinished(client) != 0)
+	{
+		CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+			configs, pollManager, fdRegistry);
+		return (1);
+	}
+	if (client.cgi.stdoutClosed && client.cgi.finished)
+		CgiCompletionHandler::finish(client, pollManager);
+	return (fdRemoved);
+}
+
+int	CgiEventHandler::writeToCgi(Client &client, PollManager &pollManager,
+	CgiFdRegistry &fdRegistry)
+{
+	if (client.cgi.stdinFd == -1 || client.cgi.stdinClosed)
+		return (0);
+	if (CgiPipeIO::hasInputFinished(client.cgi))
+	{
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
+		client.cgi.stdinFd = -1;
+		client.cgi.stdinClosed = true;
+		return (0);
+	}
+	if (CgiPipeIO::writeToStdin(client.cgi) != 0)
+		return (1);
+	if (CgiPipeIO::hasInputFinished(client.cgi))
+	{
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
+		client.cgi.stdinFd = -1;
+		client.cgi.stdinClosed = true;
+	}
+	return (0);
+}
+
+int	CgiEventHandler::readFromCgi(Client &client, PollManager &pollManager,
+	CgiFdRegistry &fdRegistry)
+{
+	CgiPipeIO::ReadResult result;
+
+	if (client.cgi.stdoutFd == -1 || client.cgi.stdoutClosed)
+		return (0);
+	result = CgiPipeIO::readFromStdout(client.cgi);
+	if (result == CgiPipeIO::READ_ERROR)
+		return (1);
+	if (result == CgiPipeIO::READ_EOF)
+	{
+		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
+		client.cgi.stdoutFd = -1;
+		client.cgi.stdoutClosed = true;
+	}
+	return (0);
+}
+
+int	CgiEventHandler::checkFinished(Client &client)
+{
+	int status;
+	pid_t result;
+
+	if (client.cgi.pid <= 0)
+		return (0);
+	result = waitpid(client.cgi.pid, &status, WNOHANG);
+	if (result == 0)
+		return (0);
+	if (result != client.cgi.pid)
+		return (1);
+	client.cgi.pid = -1;
+	client.cgi.finished = true;
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+		return (0);
+	return (1);
+}

--- a/src/CgiManager.cpp
+++ b/src/CgiManager.cpp
@@ -1,10 +1,8 @@
 #include "CgiManager.hpp"
 #include "CgiCompletionHandler.hpp"
-#include "CgiPipeIO.hpp"
+#include "CgiEventHandler.hpp"
 #include "CgiStartupHandler.hpp"
 #include "CgiTimeoutHandler.hpp"
-
-#include <sys/wait.h>
 
 CgiManager::CgiManager() {}
 
@@ -32,149 +30,22 @@ void CgiManager::cleanup(Client &client, PollManager &pollManager)
 	CgiCompletionHandler::cleanup(client, pollManager, fdRegistry);
 }
 
-int CgiManager::writeToCgi(Client &client, PollManager &pollManager)
-{
-	if (client.cgi.stdinFd == -1 || client.cgi.stdinClosed)
-		return (0);
-	if (CgiPipeIO::hasInputFinished(client.cgi))
-	{
-		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
-		client.cgi.stdinFd = -1;
-		client.cgi.stdinClosed = true;
-		return (0);
-	}
-	if (CgiPipeIO::writeToStdin(client.cgi) != 0)
-		return (1);
-	if (CgiPipeIO::hasInputFinished(client.cgi))
-	{
-		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
-		client.cgi.stdinFd = -1;
-		client.cgi.stdinClosed = true;
-	}
-	return (0);
-}
-
-int CgiManager::readFromCgi(Client &client, PollManager &pollManager)
-{
-	CgiPipeIO::ReadResult result;
-
-	if (client.cgi.stdoutFd == -1 || client.cgi.stdoutClosed)
-		return (0);
-	result = CgiPipeIO::readFromStdout(client.cgi);
-	if (result == CgiPipeIO::READ_ERROR)
-		return (1);
-	if (result == CgiPipeIO::READ_EOF)
-	{
-		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
-		client.cgi.stdoutFd = -1;
-		client.cgi.stdoutClosed = true;
-	}
-	return (0);
-}
-
-int CgiManager::checkFinished(Client &client)
-{
-	int status;
-	pid_t result;
-
-	if (client.cgi.pid <= 0)
-		return (0);
-	result = waitpid(client.cgi.pid, &status, WNOHANG);
-	if (result == 0)
-		return (0);
-	if (result != client.cgi.pid)
-		return (1);
-	client.cgi.pid = -1;
-	client.cgi.finished = true;
-	if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
-		return (0);
-	return (1);
-}
-
 int CgiManager::getPollTimeoutMs(const std::map<int, Client> &clients) const
 {
 	return (CgiTimeoutHandler::getPollTimeoutMs(clients));
 }
 
-int CgiManager::checkTimeouts(std::map<int, Client> &clients,
-	const std::vector<ServerConfig> &configs, PollManager &pollManager)
+int CgiManager::checkTimeouts(std::map<int, Client> &clients, const std::vector<ServerConfig> &configs, PollManager &pollManager)
 {
-	return (CgiTimeoutHandler::handleTimeouts(clients, configs,
-		pollManager, fdRegistry));
+	return (CgiTimeoutHandler::handleTimeouts(clients, configs, pollManager, fdRegistry));
 }
 
-int CgiManager::handleEvent(int cgiFd, short revents,
-	std::map<int, Client> &clients,
-	const std::vector<ServerConfig> &configs, PollManager &pollManager)
+int CgiManager::handleEvent(int cgiFd, short revents, std::map<int, Client> &clients, const std::vector<ServerConfig> &configs, PollManager &pollManager)
 {
-	std::map<int, Client>::iterator clientIt;
-	int fdRemoved;
-	int clientFd;
-
-	fdRemoved = 0;
-	if (!fdRegistry.getClientFd(cgiFd, clientFd))
-		return (1);
-	clientIt = clients.find(clientFd);
-	if (clientIt == clients.end())
-	{
-		fdRegistry.closeFd(cgiFd, pollManager);
-		return (1);
-	}
-
-	Client &client = clientIt->second;
-	if (revents & (POLLERR | POLLHUP | POLLNVAL))
-	{
-		if (cgiFd == client.cgi.stdinFd)
-		{
-			fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
-			client.cgi.stdinFd = -1;
-			client.cgi.stdinClosed = true;
-			fdRemoved = 1;
-		}
-		else if (cgiFd == client.cgi.stdoutFd)
-		{
-			fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
-			client.cgi.stdoutFd = -1;
-			client.cgi.stdoutClosed = true;
-			fdRemoved = 1;
-		}
-	}
-	if ((revents & POLLOUT) && cgiFd == client.cgi.stdinFd)
-	{
-		if (writeToCgi(client, pollManager) != 0)
-		{
-			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
-				configs, pollManager, fdRegistry);
-			return (1);
-		}
-		else if (client.cgi.stdinFd == -1)
-			fdRemoved = 1;
-	}
-	if ((revents & POLLIN) && cgiFd == client.cgi.stdoutFd)
-	{
-		if (readFromCgi(client, pollManager) != 0)
-		{
-			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
-				configs, pollManager, fdRegistry);
-			return (1);
-		}
-		else if (client.cgi.stdoutFd == -1)
-			fdRemoved = 1;
-	}
-	if (checkFinished(client) != 0)
-	{
-		CgiCompletionHandler::fail(client, 502, "Bad Gateway",
-			configs, pollManager, fdRegistry);
-		return (1);
-	}
-	if (client.cgi.stdoutClosed && client.cgi.finished)
-		CgiCompletionHandler::finish(client, pollManager);
-	return (fdRemoved);
+	return (CgiEventHandler::handleEvent(cgiFd, revents, clients, configs, pollManager, fdRegistry));
 }
 
-int CgiManager::startForClient(Client &client, const RouteConfig &route,
-	const ServerConfig &server, PollManager &pollManager)
+int CgiManager::startForClient(Client &client, const RouteConfig &route, const ServerConfig &server, PollManager &pollManager)
 {
-	return (CgiStartupHandler::startForClient(client, route, server,
-		pollManager, fdRegistry));
+	return (CgiStartupHandler::startForClient(client, route, server, pollManager, fdRegistry));
 }


### PR DESCRIPTION
## Summary

This PR extracts CGI poll-event handling from `CgiManager` into a dedicated `CgiEventHandler`.

## Changes

- Add `include/CgiEventHandler.hpp`
- Add `src/CgiEventHandler.cpp`
- Move CGI fd-to-client lookup into `CgiEventHandler::handleEvent`
- Move CGI fd error flag handling into event handler
- Move CGI stdin write flow into event handler
- Move CGI stdout read flow into event handler
- Move CGI process completion check with `waitpid(..., WNOHANG)` into event handler
- Move CGI event failure handling through `CgiCompletionHandler::fail`
- Move CGI event success handling through `CgiCompletionHandler::finish`
- Keep `CgiManager::handleEvent` as the public facade used by `WebServ`
- Remove private event helper declarations from `CgiManager.hpp`
- Add `CgiEventHandler.cpp` to the Makefile

## Intent

`CgiEventHandler` owns CGI poll-event orchestration, matching the existing split between `CgiStartupHandler`, `CgiTimeoutHandler`, `CgiCompletionHandler`, `CgiPipeIO`, and `CgiFdRegistry`.

`CgiManager` now acts mostly as the CGI facade while delegating startup, timeout, completion, and event-specific logic to dedicated classes.

This should not change CGI fd lookup behavior, pipe read/write behavior, process completion checks, bad gateway handling, successful CGI completion, or returned `fdRemoved` values.
