### PR TITLE
Refactor client event handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientEventHandler.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/ClientEventHandler.hpp
+++ b/include/ClientEventHandler.hpp
@@ -1,0 +1,27 @@
+#ifndef CLIENTEVENTHANDLER_HPP
+#define CLIENTEVENTHANDLER_HPP
+
+#include "CgiManager.hpp"
+#include "Client.hpp"
+#include "Config.hpp"
+#include "PollManager.hpp"
+
+class ClientEventHandler
+{
+	public:
+		enum Result
+		{
+			EVENT_HANDLED,
+			CLIENT_SHOULD_CLOSE,
+			EVENT_FAILED
+		};
+
+		static Result handle(Client &client, short revents,
+			const ServerConfig &server, CgiManager &cgiManager,
+			PollManager &pollManager);
+
+	private:
+		ClientEventHandler();
+};
+
+#endif

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -20,8 +20,6 @@ public:
 	WebServ(const WebServ &other);
 	~WebServ();
 	WebServ &operator=(const WebServ &other);
-	int readFromClient(Client &client);
-	int SendToClient(Client &client);
 
 	int setup(std::vector<ServerConfig> servers);
 	int run();
@@ -35,7 +33,6 @@ private:
 	CgiManager cgiManager;
 
 	int setNonBlocking(int fd);
-	int discardRequestBody(Client &client);
 	void closeAndRemoveFd(int fd);
 	std::vector<ServerConfig> configs;
 	std::map<int, size_t> listenerFdToIndex;

--- a/src/ClientEventHandler.cpp
+++ b/src/ClientEventHandler.cpp
@@ -1,0 +1,264 @@
+#include "ClientEventHandler.hpp"
+#include "ClientResponseApplier.hpp"
+#include "ErrorResponseHandler.hpp"
+#include "RequestDispatcher.hpp"
+#include "RequestInspector.hpp"
+#include "RequestParser.hpp"
+#include "Response.hpp"
+#include <iostream>
+#include <poll.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+namespace
+{
+	enum ReadEventResult
+	{
+		READ_EVENT_CONTINUE,
+		READ_EVENT_DONE,
+		READ_EVENT_CLOSE
+	};
+
+	int readFromClient(Client &client)
+	{
+		ssize_t	bytesRead;
+		char	buffer[4096];
+
+		bytesRead = recv(client.fd, buffer, sizeof(buffer), 0);
+		if (bytesRead < 0)
+		{
+			std::cerr << "Failed to read from client fd " << client.fd << std::endl;
+			client.state = CLOSING_CONNECTION;
+			return (1);
+		}
+		if (bytesRead == 0)
+		{
+			std::cout << "Client closed connection" << std::endl;
+			client.state = CLOSING_CONNECTION;
+			return (0);
+		}
+		client.rawRequest.append(buffer, static_cast<size_t>(bytesRead));
+		return (0);
+	}
+
+	int discardRequestBody(Client &client)
+	{
+		ssize_t	bytesRead;
+		char	buffer[4096];
+		size_t	readSize;
+
+		if (client.bodyBytesToDiscard == 0)
+		{
+			client.state = WRITING;
+			return (0);
+		}
+		readSize = sizeof(buffer);
+		if (client.bodyBytesToDiscard < readSize)
+			readSize = client.bodyBytesToDiscard;
+		bytesRead = recv(client.fd, buffer, readSize, 0);
+		if (bytesRead < 0)
+		{
+			std::cerr << "Failed to discard request body from client fd "
+				<< client.fd << std::endl;
+			client.state = CLOSING_CONNECTION;
+			return (1);
+		}
+		if (bytesRead == 0)
+		{
+			client.bodyBytesToDiscard = 0;
+			client.state = WRITING;
+			return (0);
+		}
+		if (static_cast<size_t>(bytesRead) >= client.bodyBytesToDiscard)
+		{
+			client.bodyBytesToDiscard = 0;
+			client.state = WRITING;
+		}
+		else
+			client.bodyBytesToDiscard -= static_cast<size_t>(bytesRead);
+		return (0);
+	}
+
+	int sendToClient(Client &client, const ServerConfig &server,
+		CgiManager &cgiManager, PollManager &pollManager)
+	{
+		RequestDispatcher::Result	dispatchResult;
+		ssize_t					bytesSent;
+		size_t					remaining;
+		const char				*data;
+
+		if (!client.responseReady)
+		{
+			dispatchResult = RequestDispatcher::dispatch(client, server,
+				cgiManager, pollManager);
+			if (dispatchResult == RequestDispatcher::DISPATCH_FAILED)
+				return (1);
+			if (dispatchResult == RequestDispatcher::ASYNC_STARTED)
+				return (0);
+		}
+		if (client.bytesSent >= client.responseBuffer.size())
+		{
+			client.state = CLOSING_CONNECTION;
+			return (0);
+		}
+		remaining = client.responseBuffer.size() - client.bytesSent;
+		data = client.responseBuffer.c_str() + client.bytesSent;
+		bytesSent = send(client.fd, data, remaining, 0);
+		if (bytesSent <= 0)
+		{
+			std::cerr << "Failed to send response to client fd "
+				<< client.fd << std::endl;
+			client.state = CLOSING_CONNECTION;
+			return (1);
+		}
+		client.bytesSent += static_cast<size_t>(bytesSent);
+		if (client.bytesSent >= client.responseBuffer.size())
+			client.state = CLOSING_CONNECTION;
+		return (0);
+	}
+
+	std::string getInspectorErrorMessage(InspectRequestStatus status)
+	{
+		if (status == BAD_REQUEST)
+			return ("Bad Request");
+		if (status == REQUEST_TOO_LARGE)
+			return ("Payload Too Large");
+		if (status == URI_TOO_LONG)
+			return ("URI Too Long");
+		if (status == HEADER_TOO_LARGE)
+			return ("Request Header Fields Too Large");
+		if (status == NOT_IMPLEMENTED)
+			return ("Not Implemented");
+		return ("Bad Request");
+	}
+
+	void prepareInspectorErrorResponse(Client &client,
+		const ServerConfig &server, InspectRequestStatus status)
+	{
+		Response	response;
+		int			statusCode;
+
+		statusCode = static_cast<int>(status);
+		if (statusCode < 400 || statusCode > 599)
+			statusCode = 400;
+		response = ErrorResponseHandler::build(statusCode,
+			getInspectorErrorMessage(status), server);
+		ClientResponseApplier::apply(client, response);
+	}
+
+	void prepareBodyDiscard(Client &client, const RequestInspection &inspection)
+	{
+		size_t	currentBodySize;
+
+		client.bodyBytesToDiscard = 0;
+		if (!inspection.hasContentLength)
+			return;
+		currentBodySize = 0;
+		if (client.rawRequest.length() > inspection.bodyStart)
+			currentBodySize = client.rawRequest.length() - inspection.bodyStart;
+		if (currentBodySize < inspection.contentLength)
+		{
+			client.bodyBytesToDiscard = inspection.contentLength - currentBodySize;
+			client.state = DISCARDING_BODY;
+		}
+	}
+
+	ClientEventHandler::Result handleDiscardingBody(Client &client,
+		short revents, PollManager &pollManager)
+	{
+		if (revents & POLLIN)
+		{
+			discardRequestBody(client);
+			if (client.state == CLOSING_CONNECTION)
+				return (ClientEventHandler::CLIENT_SHOULD_CLOSE);
+			if (client.state == WRITING)
+				pollManager.setEvents(client.fd, POLLOUT);
+		}
+		return (ClientEventHandler::EVENT_HANDLED);
+	}
+
+	ClientEventHandler::Result handleActiveCgiClient(Client &client,
+		short revents)
+	{
+		if (revents & POLLIN)
+		{
+			readFromClient(client);
+			if (client.state == CLOSING_CONNECTION)
+				return (ClientEventHandler::CLIENT_SHOULD_CLOSE);
+			client.rawRequest.clear();
+		}
+		return (ClientEventHandler::EVENT_HANDLED);
+	}
+
+	ReadEventResult inspectClientRequest(Client &client,
+		const ServerConfig &server, PollManager &pollManager)
+	{
+		RequestParser		parser;
+		RequestInspector	inspector;
+		RequestInspection	inspection;
+
+		inspection = inspector.inspectRequest(client.getRawRequest(),
+			server.clientMaxBodySize);
+		if (inspection.status == COMPLETED)
+		{
+			parser.parse(client.getRawRequest(), client.request, inspection);
+			pollManager.setEvents(client.fd, POLLOUT);
+			return (READ_EVENT_CONTINUE);
+		}
+		if (inspection.status == NEED_MORE_DATA)
+			return (READ_EVENT_DONE);
+		prepareInspectorErrorResponse(client, server, inspection.status);
+		if (inspection.status == REQUEST_TOO_LARGE)
+			prepareBodyDiscard(client, inspection);
+		if (client.state == DISCARDING_BODY)
+			pollManager.setEvents(client.fd, POLLIN);
+		else
+			pollManager.setEvents(client.fd, POLLOUT);
+		return (READ_EVENT_DONE);
+	}
+
+	ReadEventResult handleReadEvent(Client &client,
+		const ServerConfig &server, PollManager &pollManager)
+	{
+		client.state = READING;
+		readFromClient(client);
+		if (client.state == CLOSING_CONNECTION)
+			return (READ_EVENT_CLOSE);
+		return (inspectClientRequest(client, server, pollManager));
+	}
+
+	ClientEventHandler::Result handleWriteEvent(Client &client,
+		const ServerConfig &server, CgiManager &cgiManager,
+		PollManager &pollManager)
+	{
+		client.state = WRITING;
+		sendToClient(client, server, cgiManager, pollManager);
+		if (client.state == CLOSING_CONNECTION)
+			return (ClientEventHandler::CLIENT_SHOULD_CLOSE);
+		return (ClientEventHandler::EVENT_HANDLED);
+	}
+}
+
+ClientEventHandler::Result ClientEventHandler::handle(Client &client,
+	short revents, const ServerConfig &server, CgiManager &cgiManager,
+	PollManager &pollManager)
+{
+	ReadEventResult	readResult;
+
+	if (client.state == DISCARDING_BODY)
+		return (handleDiscardingBody(client, revents, pollManager));
+	if (client.state == CGI_WRITING || client.state == CGI_READING)
+		return (handleActiveCgiClient(client, revents));
+	if (revents & POLLIN)
+	{
+		readResult = handleReadEvent(client, server, pollManager);
+		if (readResult == READ_EVENT_CLOSE)
+			return (CLIENT_SHOULD_CLOSE);
+		if (readResult == READ_EVENT_DONE)
+			return (EVENT_HANDLED);
+	}
+	if (revents & POLLOUT)
+		return (handleWriteEvent(client, server, cgiManager, pollManager));
+	return (EVENT_HANDLED);
+}

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -1,8 +1,5 @@
 #include "WebServ.hpp"
-#include "Request.hpp"
-#include "RequestInspector.hpp"
-#include "RequestParser.hpp"
-#include "Response.hpp"
+#include "ClientEventHandler.hpp"
 #include <cerrno>
 #include <cstring>
 #include <fcntl.h>
@@ -13,16 +10,6 @@
 #include <sys/poll.h>
 #include <sys/socket.h>
 #include <utility>
-
-#include "CgiHandler.hpp"
-#include "ClientResponseApplier.hpp"
-#include "RequestDispatcher.hpp"
-#include "ErrorResponseHandler.hpp"
-
-#include <ctime>
-#include <signal.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
 
 WebServ::WebServ()
 {
@@ -60,110 +47,6 @@ int WebServ::setNonBlocking(int fd)
 		std::cerr << "fcntl: " << strerror(errno) << "\n";
 		return (1);
 	}
-	return (0);
-}
-
-int WebServ::readFromClient(Client &client)
-{
-	ssize_t	bytesRead;
-	char	buffer[4096];
-
-	bytesRead = recv(client.fd, buffer, sizeof(buffer), 0);
-	if (bytesRead < 0)
-	{
-		std::cerr << "Failed to read from client fd " << client.fd << std::endl;
-		client.state = CLOSING_CONNECTION;
-		return (1);
-	}
-	if (bytesRead == 0)
-	{
-		std::cout << "Client closed connection" << std::endl;
-		client.state = CLOSING_CONNECTION;
-		return (0);
-	}
-	client.rawRequest.append(buffer, static_cast<size_t>(bytesRead));
-	return (0);
-}
-
-int WebServ::discardRequestBody(Client &client)
-{
-	ssize_t bytesRead;
-	char buffer[4096];
-	size_t readSize;
-
-	if (client.bodyBytesToDiscard == 0)
-	{
-		client.state = WRITING;
-		return (0);
-	}
-	readSize = sizeof(buffer);
-	if (client.bodyBytesToDiscard < readSize)
-		readSize = client.bodyBytesToDiscard;
-	bytesRead = recv(client.fd, buffer, readSize, 0);
-	if (bytesRead < 0)
-	{
-		std::cerr << "Failed to discard request body from client fd "
-				  << client.fd << std::endl;
-		client.state = CLOSING_CONNECTION;
-		return (1);
-	}
-	if (bytesRead == 0)
-	{
-		client.bodyBytesToDiscard = 0;
-		client.state = WRITING;
-		return (0);
-	}
-	if (static_cast<size_t>(bytesRead) >= client.bodyBytesToDiscard)
-	{
-		client.bodyBytesToDiscard = 0;
-		client.state = WRITING;
-	}
-	else
-		client.bodyBytesToDiscard -= static_cast<size_t>(bytesRead);
-	return (0);
-}
-
-int WebServ::SendToClient(Client &client)
-{
-	RequestDispatcher::Result dispatchResult;
-	ssize_t bytesSent;
-	size_t remaining;
-	const char *data;
-
-	if (!client.responseReady)
-	{
-		dispatchResult = RequestDispatcher::dispatch(client, configs[client.serverIndex],
-											 cgiManager, pollManager);
-
-		if (dispatchResult == RequestDispatcher::DISPATCH_FAILED)
-			return (1);
-		if (dispatchResult == RequestDispatcher::ASYNC_STARTED)
-			return (0);
-	}
-
-	if (client.bytesSent >= client.responseBuffer.size())
-	{
-		client.state = CLOSING_CONNECTION;
-		return (0);
-	}
-
-	remaining = client.responseBuffer.size() - client.bytesSent;
-	data = client.responseBuffer.c_str() + client.bytesSent;
-	bytesSent = send(client.fd, data, remaining, 0);
-
-	if (bytesSent <= 0)
-	{
-		std::cerr << "Failed to send response to client fd "
-				  << client.fd << std::endl;
-		client.state = CLOSING_CONNECTION;
-		return (1);
-	}
-
-	client.bytesSent += static_cast<size_t>(bytesSent);
-
-	if (client.bytesSent >= client.responseBuffer.size())
-		client.state = CLOSING_CONNECTION;
-
 	return (0);
 }
 
@@ -360,49 +243,10 @@ void WebServ::closeAndRemoveFd(int fd)
 	listenerFdToIndex.erase(fd);
 }
 
-static std::string getInspectorErrorMessage(InspectRequestStatus status)
+static bool shouldCloseClient(ClientEventHandler::Result result)
 {
-	if (status == BAD_REQUEST)
-		return ("Bad Request");
-	if (status == REQUEST_TOO_LARGE)
-		return ("Payload Too Large");
-	if (status == URI_TOO_LONG)
-		return ("URI Too Long");
-	if (status == HEADER_TOO_LARGE)
-		return ("Request Header Fields Too Large");
-	if (status == NOT_IMPLEMENTED)
-		return ("Not Implemented");
-	return ("Bad Request");
-}
-
-static void prepareInspectorErrorResponse(Client &client, const ServerConfig &server, InspectRequestStatus status)
-{
-	Response response;
-	int statusCode;
-
-	statusCode = static_cast<int>(status);
-	if (statusCode < 400 || statusCode > 599)
-		statusCode = 400;
-
-	response = ErrorResponseHandler::build(statusCode, getInspectorErrorMessage(status), server);
-	ClientResponseApplier::apply(client, response);
-}
-
-static void prepareBodyDiscard(Client &client, const RequestInspection &inspection)
-{
-	size_t currentBodySize;
-
-	client.bodyBytesToDiscard = 0;
-	if (!inspection.hasContentLength)
-		return;
-	currentBodySize = 0;
-	if (client.rawRequest.length() > inspection.bodyStart)
-		currentBodySize = client.rawRequest.length() - inspection.bodyStart;
-	if (currentBodySize < inspection.contentLength)
-	{
-		client.bodyBytesToDiscard = inspection.contentLength - currentBodySize;
-		client.state = DISCARDING_BODY;
-	}
+	return (result == ClientEventHandler::CLIENT_SHOULD_CLOSE
+		|| result == ClientEventHandler::EVENT_FAILED);
 }
 
 int WebServ::run()
@@ -474,89 +318,15 @@ int WebServ::run()
 					continue;
 				}
 
+				ClientEventHandler::Result result;
 				Client &curClient = clientIt->second;
-				if (curClient.state == DISCARDING_BODY)
+
+				result = ClientEventHandler::handle(curClient, pollFds[i].revents,
+					configs[curClient.serverIndex], cgiManager, pollManager);
+				if (shouldCloseClient(result))
 				{
-					if (pollFds[i].revents & POLLIN)
-					{
-						discardRequestBody(curClient);
-						if (curClient.state == CLOSING_CONNECTION)
-						{
-							closeAndRemoveFd(curFD);
-							continue;
-						}
-						if (curClient.state == WRITING)
-							pollManager.setEvents(curFD, POLLOUT);
-					}
-					++i;
+					closeAndRemoveFd(curFD);
 					continue;
-				}
-				if (curClient.state == CGI_WRITING || curClient.state == CGI_READING)
-				{
-					if (pollFds[i].revents & POLLIN)
-					{
-						readFromClient(curClient);
-						if (curClient.state == CLOSING_CONNECTION)
-						{
-							closeAndRemoveFd(curFD);
-							continue;
-						}
-						curClient.rawRequest.clear();
-					}
-					++i;
-					continue;
-				}
-				if (pollFds[i].revents & POLLIN)
-				{
-					curClient.state = READING;
-					readFromClient(curClient);
-					if (curClient.state == CLOSING_CONNECTION)
-					{
-						closeAndRemoveFd(curFD);
-						continue;
-					}
-
-					RequestParser parser;
-					RequestInspector inspector;
-					RequestInspection inspection;
-
-					inspection = inspector.inspectRequest(curClient.getRawRequest(),
-						configs[curClient.serverIndex].clientMaxBodySize);
-					if (inspection.status == COMPLETED)
-					{
-						parser.parse(curClient.getRawRequest(), curClient.request, inspection);
-					}
-					else if (inspection.status == NEED_MORE_DATA)
-					{
-						++i;
-						continue;
-					}
-					else
-					{
-						prepareInspectorErrorResponse(curClient, configs[curClient.serverIndex],
-							inspection.status);
-						if (inspection.status == REQUEST_TOO_LARGE)
-							prepareBodyDiscard(curClient, inspection);
-						if (curClient.state == DISCARDING_BODY)
-							pollManager.setEvents(curFD, POLLIN);
-						else
-							pollManager.setEvents(curFD, POLLOUT);
-						++i;
-						continue;
-					}
-
-					// TODO: if request is valid set as POLLOUT
-					pollManager.setEvents(curFD, POLLOUT);
-				}
-				if (pollFds[i].revents & POLLOUT)
-				{
-					curClient.state = WRITING;
-					SendToClient(curClient);
-					if (curClient.state == CLOSING_CONNECTION)
-					{
-						closeAndRemoveFd(curFD);
-						continue;
-					}
 				}
 			}
 			++i;


### PR DESCRIPTION
## Summary

This PR extracts client-specific poll event handling from `WebServ::run()` into `ClientEventHandler`.

## Changes

- Delegate client fd processing from `WebServ::run()` to `ClientEventHandler::handle`
- Move client read/write/discard/inspection flow out of `WebServ.cpp`
- Keep listener fd handling and CGI fd handling in `WebServ` for now
- Add `ClientEventHandler.cpp` to the Makefile source list

## Scope

This is intended as a behavior-preserving refactor.

## Not included

- No listener socket extraction
- No new EventLoop class
- No CGI behavior changes
- No HTTP behavior changes
- No logging cleanup

## Validation

I could not run `make` from this environment because the local container cannot resolve `github.com` for cloning. Please validate locally with:

```bash
make fclean && make
python3 tests/regression_tester.py compare --build --check-relink --baseline tests/baselines/before_architecture_refactor.json
python3 tests/regression_tester.py check --build --stress
```