### PR TITLE
Refactor listener socket handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientEventHandler.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp
+SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientEventHandler.cpp ClientResponseApplier.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp ListenerSocketHandler.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/ListenerSocketHandler.hpp
+++ b/include/ListenerSocketHandler.hpp
@@ -6,6 +6,7 @@
 #include "PollManager.hpp"
 #include <cstddef>
 #include <map>
+#include <string>
 #include <vector>
 
 class ListenerSocketHandler

--- a/include/ListenerSocketHandler.hpp
+++ b/include/ListenerSocketHandler.hpp
@@ -1,0 +1,38 @@
+#ifndef LISTENERSOCKETHANDLER_HPP
+#define LISTENERSOCKETHANDLER_HPP
+
+#include "Client.hpp"
+#include "Config.hpp"
+#include "PollManager.hpp"
+#include <cstddef>
+#include <map>
+#include <vector>
+
+class ListenerSocketHandler
+{
+	public:
+		ListenerSocketHandler();
+		ListenerSocketHandler(const ListenerSocketHandler &other);
+		~ListenerSocketHandler();
+		ListenerSocketHandler &operator=(const ListenerSocketHandler &other);
+
+		int setup(const std::vector<ServerConfig> &configs,
+			PollManager &pollManager);
+		int acceptConnection(int listeningSocket,
+			std::map<int, Client> &clients, PollManager &pollManager);
+		bool isListeningFd(int fd) const;
+		void removeFd(int fd);
+
+	private:
+		std::map<int, size_t> listenerFdToIndex;
+
+		int initListeningSocket(void) const;
+		int bindSockAddress(int listeningSocket,
+			const ServerConfig &config) const;
+		int setupSingleListener(const ServerConfig &config, size_t configIndex,
+			PollManager &pollManager);
+		int setNonBlocking(int fd) const;
+		std::string ipToString(unsigned int address) const;
+};
+
+#endif

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -1,15 +1,13 @@
 #ifndef WEBSERV_HPP
 #define WEBSERV_HPP
 
+#include "CgiManager.hpp"
 #include "Client.hpp"
 #include "Config.hpp"
+#include "ListenerSocketHandler.hpp"
 #include "PollManager.hpp"
-#include "CgiManager.hpp"
 #include <map>
-#include <netinet/in.h>
 #include <poll.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 #include <vector>
 
@@ -23,19 +21,14 @@ public:
 
 	int setup(std::vector<ServerConfig> servers);
 	int run();
-	int initListeningSocket();
-	int bindSockAddress(int listeningSocket, size_t configIndex);
-	int acceptConnection(int listeningSocket);
-	bool isListeningFd(int fd);
 
 private:
 	PollManager pollManager;
 	CgiManager cgiManager;
+	ListenerSocketHandler listenerSocketHandler;
 
-	int setNonBlocking(int fd);
 	void closeAndRemoveFd(int fd);
 	std::vector<ServerConfig> configs;
-	std::map<int, size_t> listenerFdToIndex;
 	std::map<int, Client> clients;
 
 };

--- a/src/ListenerSocketHandler.cpp
+++ b/src/ListenerSocketHandler.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sstream>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -81,6 +82,7 @@ int ListenerSocketHandler::bindSockAddress(int listeningSocket,
 	std::stringstream	ss;
 	std::string		portStr;
 	const char		*hostCstr;
+	int				ret;
 
 	res = NULL;
 	std::memset(&hints, 0, sizeof(hints));
@@ -92,9 +94,11 @@ int ListenerSocketHandler::bindSockAddress(int listeningSocket,
 	hostCstr = NULL;
 	if (!config.listen.host.empty())
 		hostCstr = config.listen.host.c_str();
-	if (getaddrinfo(hostCstr, portStr.c_str(), &hints, &res))
+	ret = getaddrinfo(hostCstr, portStr.c_str(), &hints, &res);
+	if (ret)
 	{
-		std::cerr << "getaddrinfo: " << gai_strerror(errno) << "\n";
+		std::cerr << "getaddrinfo: " << gai_strerror(ret) << "\n";
+		close(listeningSocket);
 		return (1);
 	}
 	if (bind(listeningSocket, res->ai_addr, res->ai_addrlen) == -1)

--- a/src/ListenerSocketHandler.cpp
+++ b/src/ListenerSocketHandler.cpp
@@ -1,0 +1,215 @@
+#include "ListenerSocketHandler.hpp"
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sstream>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <utility>
+
+ListenerSocketHandler::ListenerSocketHandler()
+{
+}
+
+ListenerSocketHandler::ListenerSocketHandler(const ListenerSocketHandler &other)
+{
+	*this = other;
+}
+
+ListenerSocketHandler::~ListenerSocketHandler()
+{
+}
+
+ListenerSocketHandler &ListenerSocketHandler::operator=(
+	const ListenerSocketHandler &other)
+{
+	if (this != &other)
+		listenerFdToIndex = other.listenerFdToIndex;
+	return (*this);
+}
+
+int ListenerSocketHandler::setNonBlocking(int fd) const
+{
+	int flags;
+
+	flags = fcntl(fd, F_GETFL, 0);
+	if (flags == -1)
+	{
+		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		return (1);
+	}
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+	{
+		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		return (1);
+	}
+	return (0);
+}
+
+int ListenerSocketHandler::initListeningSocket(void) const
+{
+	int listeningSocket;
+	int opt;
+
+	listeningSocket = socket(AF_INET, SOCK_STREAM, 0);
+	if (listeningSocket == -1)
+	{
+		std::cerr << "socket() failed: " << std::strerror(errno) << "\n";
+		return (-1);
+	}
+	std::cout << "Server socked created, FD = " << listeningSocket << "\n";
+	opt = 1;
+	if (setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR,
+			&opt, sizeof(opt)) == -1)
+	{
+		std::cerr << "setsockopt() failed: " << std::strerror(errno) << "\n";
+		close(listeningSocket);
+		return (-1);
+	}
+	return (listeningSocket);
+}
+
+int ListenerSocketHandler::bindSockAddress(int listeningSocket,
+	const ServerConfig &config) const
+{
+	struct addrinfo	hints;
+	struct addrinfo	*res;
+	std::stringstream	ss;
+	std::string		portStr;
+	const char		*hostCstr;
+
+	res = NULL;
+	std::memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = 0;
+	ss << config.listen.port;
+	portStr = ss.str();
+	hostCstr = NULL;
+	if (!config.listen.host.empty())
+		hostCstr = config.listen.host.c_str();
+	if (getaddrinfo(hostCstr, portStr.c_str(), &hints, &res))
+	{
+		std::cerr << "getaddrinfo: " << gai_strerror(errno) << "\n";
+		return (1);
+	}
+	if (bind(listeningSocket, res->ai_addr, res->ai_addrlen) == -1)
+	{
+		std::cerr << "Error binding socket\n" << std::strerror(errno) << "\n";
+		freeaddrinfo(res);
+		close(listeningSocket);
+		return (1);
+	}
+	freeaddrinfo(res);
+	return (0);
+}
+
+int ListenerSocketHandler::setupSingleListener(const ServerConfig &config,
+	size_t configIndex, PollManager &pollManager)
+{
+	int listeningSocket;
+
+	listeningSocket = initListeningSocket();
+	if (listeningSocket == -1)
+		return (1);
+	if (bindSockAddress(listeningSocket, config))
+		return (1);
+	if (listen(listeningSocket, 10) == -1)
+	{
+		std::cerr << "Error on socket " << configIndex << " listening\n";
+		close(listeningSocket);
+		return (1);
+	}
+	if (setNonBlocking(listeningSocket))
+	{
+		std::cerr << "Error setting socket " << configIndex
+			<< " as Non blocking\n";
+		close(listeningSocket);
+		return (1);
+	}
+	listenerFdToIndex[listeningSocket] = configIndex;
+	pollManager.addFd(listeningSocket, POLLIN);
+	std::cout << "Listening on " << config.listen.host << ":"
+		<< config.listen.port << "\n";
+	return (0);
+}
+
+int ListenerSocketHandler::setup(const std::vector<ServerConfig> &configs,
+	PollManager &pollManager)
+{
+	size_t	i;
+	bool	stop;
+
+	stop = true;
+	i = 0;
+	while (i < configs.size())
+	{
+		if (setupSingleListener(configs[i], i, pollManager))
+			std::cerr << "Server Block " << i << " setup failed!\n";
+		else
+			stop = false;
+		++i;
+	}
+	if (stop)
+		return (1);
+	return (0);
+}
+
+std::string ListenerSocketHandler::ipToString(unsigned int address) const
+{
+	std::ostringstream	oss;
+	unsigned int		hostAddress;
+
+	hostAddress = ntohl(address);
+	oss << ((hostAddress >> 24) & 255) << "." << ((hostAddress >> 16) & 255)
+		<< "." << ((hostAddress >> 8) & 255) << "." << (hostAddress & 255);
+	return (oss.str());
+}
+
+int ListenerSocketHandler::acceptConnection(int listeningSocket,
+	std::map<int, Client> &clients, PollManager &pollManager)
+{
+	sockaddr_in					clientAddress;
+	socklen_t					clientAddressLength;
+	int							clientSocket;
+	std::map<int, Client>::iterator	clientIt;
+
+	clientAddressLength = sizeof(clientAddress);
+	clientSocket = accept(listeningSocket, (sockaddr *)&clientAddress,
+		&clientAddressLength);
+	if (clientSocket == -1)
+	{
+		if (errno != EAGAIN && errno != EWOULDBLOCK)
+			std::cerr << "accept: " << strerror(errno) << std::endl;
+		return (-1);
+	}
+	if (setNonBlocking(clientSocket))
+	{
+		std::cerr << "fcntl: " << strerror(errno) << std::endl;
+		close(clientSocket);
+		return (-1);
+	}
+	pollManager.addFd(clientSocket, POLLIN);
+	clients.insert(std::make_pair(clientSocket, Client(clientSocket)));
+	clientIt = clients.find(clientSocket);
+	if (clientIt != clients.end())
+	{
+		clientIt->second.setRemoteAddr(ipToString(clientAddress.sin_addr.s_addr));
+		clientIt->second.serverIndex = listenerFdToIndex[listeningSocket];
+	}
+	return (clientSocket);
+}
+
+bool ListenerSocketHandler::isListeningFd(int fd) const
+{
+	return (listenerFdToIndex.find(fd) != listenerFdToIndex.end());
+}
+
+void ListenerSocketHandler::removeFd(int fd)
+{
+	listenerFdToIndex.erase(fd);
+}

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -2,14 +2,10 @@
 #include "ClientEventHandler.hpp"
 #include <cerrno>
 #include <cstring>
-#include <fcntl.h>
 #include <iostream>
-#include <netdb.h>
 #include <poll.h>
-#include <sstream>
 #include <sys/poll.h>
-#include <sys/socket.h>
-#include <utility>
+#include <unistd.h>
 
 WebServ::WebServ()
 {
@@ -34,188 +30,11 @@ WebServ &WebServ::operator=(const WebServ &other)
 	return (*this);
 }
 
-int WebServ::setNonBlocking(int fd)
-{
-	int flags = fcntl(fd, F_GETFL, 0);
-	if (flags == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	return (0);
-}
-
-int WebServ::initListeningSocket()
-{
-	int tmpSocket = socket(AF_INET, SOCK_STREAM, 0);
-	if (tmpSocket == -1)
-	{
-		std::cerr << "socket() failed: " << std::strerror(errno) << "\n";
-		return (-1);
-	}
-
-	std::cout << "Server socked created, FD = " << tmpSocket << "\n";
-
-	int opt = 1;
-	if (setsockopt(
-			tmpSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) ==
-		-1)
-	{
-		std::cerr << "setsockopt() failed: " << std::strerror(errno) << "\n";
-		close(tmpSocket);
-		return (-1);
-	}
-	return (tmpSocket);
-}
-
-int WebServ::bindSockAddress(int listeningSocket, size_t configIndex)
-{
-
-	struct addrinfo hints;
-	struct addrinfo *res = NULL;
-
-	std::memset(&hints, 0, sizeof(hints));
-
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = 0;
-
-	std::stringstream ss;
-	ss << configs[configIndex].listen.port;
-	std::string port_str = ss.str();
-
-	const char *host_cstr = NULL;
-	if (!configs[configIndex].listen.host.empty())
-	{
-		host_cstr = configs[configIndex].listen.host.c_str();
-	}
-
-	int ret = getaddrinfo(host_cstr, port_str.c_str(), &hints, &res);
-	if (ret)
-	{
-		std::cerr << "getaddrinfo: " << gai_strerror(ret) << "\n";
-		return (1);
-	}
-
-	if (bind(listeningSocket, res->ai_addr, res->ai_addrlen) == -1)
-	{
-		std::cerr << "Error binding socket\n"
-				  << std::strerror(errno) << "\n";
-		freeaddrinfo(res);
-		close(listeningSocket);
-		return (1);
-	}
-	freeaddrinfo(res);
-	return (0);
-}
-
 int WebServ::setup(std::vector<ServerConfig> servers)
 {
-	// TODO: add created ListenerSockets to pollfds and to map
 	std::cout << "WebServ setup called!\n";
-
-	this->configs = servers; // Refactor instead of copying?
-	bool stop = true;
-	for (size_t i = 0; i < servers.size(); ++i)
-	{
-		ServerConfig &tmpConfig = servers[i];
-
-		// 1. Create socket
-		int listeningSocket = initListeningSocket();
-		if (listeningSocket == -1)
-		{
-			std::cerr << "Server Block " << i << " setup failed!\n";
-			continue;
-		}
-
-		// 2. Setup address for socket
-		if (bindSockAddress(listeningSocket, i))
-		{
-			std::cerr << "Server Block " << i << " setup failed!\n";
-			continue;
-		}
-
-		// 3. Socket listening
-		if (listen(listeningSocket, 10) == -1)
-		{
-			std::cerr << "Error on socket " << i << " listening\n";
-			close(listeningSocket);
-			continue;
-		}
-		if (setNonBlocking(listeningSocket))
-		{
-			std::cerr << "Error setting socket " << i << " as Non blocking\n";
-			close(listeningSocket);
-			continue;
-		}
-
-		listenerFdToIndex[listeningSocket] = i;
-
-		pollManager.addFd(listeningSocket, POLLIN);
-
-		std::cout << "Listening on " << tmpConfig.listen.host << ":"
-				  << tmpConfig.listen.port << "\n";
-		stop = false;
-	}
-	if (stop)
-		return (1);
-	return (0);
-}
-
-static std::string ipToString(uint32_t address)
-{
-	std::ostringstream oss;
-	uint32_t hostAddress;
-
-	hostAddress = ntohl(address);
-	oss << ((hostAddress >> 24) & 255) << "." << ((hostAddress >> 16) & 255)
-		<< "." << ((hostAddress >> 8) & 255) << "." << (hostAddress & 255);
-	return (oss.str());
-}
-
-int WebServ::acceptConnection(int listeningSocket)
-{
-	sockaddr_in clientAddress;
-	socklen_t clientAddressLength;
-	int clientSocket;
-	std::map<int, Client>::iterator clientIt;
-
-	clientAddressLength = sizeof(clientAddress);
-	clientSocket = accept(listeningSocket, (sockaddr *)&clientAddress, &clientAddressLength);
-	if (clientSocket == -1)
-	{
-		if (errno != EAGAIN && errno != EWOULDBLOCK)
-			std::cerr << "accept: " << strerror(errno) << std::endl;
-		return (-1);
-	}
-
-	if (setNonBlocking(clientSocket))
-	{
-		std::cerr << "fcntl: " << strerror(errno) << std::endl;
-		close(clientSocket);
-		return (-1);
-	}
-
-	pollManager.addFd(clientSocket, POLLIN);
-
-	clients.insert(std::make_pair(clientSocket, Client(clientSocket)));
-	clientIt = clients.find(clientSocket);
-	if (clientIt != clients.end())
-	{
-		clientIt->second.setRemoteAddr(ipToString(clientAddress.sin_addr.s_addr));
-		clientIt->second.serverIndex = listenerFdToIndex[listeningSocket];
-	}
-	return (clientSocket);
-}
-
-bool WebServ::isListeningFd(int fd)
-{
-	return (this->listenerFdToIndex.find(fd) != this->listenerFdToIndex.end());
+	configs = servers;
+	return (listenerSocketHandler.setup(configs, pollManager));
 }
 
 static bool hasActiveCgi(const Client &client)
@@ -240,7 +59,7 @@ void WebServ::closeAndRemoveFd(int fd)
 
 	close(fd);
 	pollManager.removeFd(fd);
-	listenerFdToIndex.erase(fd);
+	listenerSocketHandler.removeFd(fd);
 }
 
 static bool shouldCloseClient(ClientEventHandler::Result result)
@@ -301,10 +120,10 @@ int WebServ::run()
 
 			// Accept connections
 
-			if (isListeningFd(curFD))
+			if (listenerSocketHandler.isListeningFd(curFD))
 			{
 				if (pollFds[i].revents & POLLIN)
-					acceptConnection(curFD);
+					listenerSocketHandler.acceptConnection(curFD, clients, pollManager);
 
 				++i;
 				continue;


### PR DESCRIPTION
## Summary

This PR extracts listener socket setup and accept handling from `WebServ` into a dedicated `ListenerSocketHandler` component.

## Changes

- Add `include/ListenerSocketHandler.hpp`
- Add `src/ListenerSocketHandler.cpp`
- Move listener socket creation, bind, listen and non-blocking setup out of `WebServ.cpp`
- Move accept handling and listener fd-to-server-index mapping into `ListenerSocketHandler`
- Replace `listenerFdToIndex` in `WebServ` with `ListenerSocketHandler`
- Keep the single `poll()` loop in `WebServ::run()` unchanged in principle
- Add `ListenerSocketHandler.cpp` to the Makefile source list

## Scope

This is intended as a behavior-preserving architecture refactor.

## Not included

- No new EventLoop class
- No CGI behavior changes
- No client state machine changes
- No HTTP parsing or response behavior changes
- No logging cleanup

## Validation

Please validate locally with:

```bash
make fclean && make
python3 tests/regression_tester.py compare --build --check-relink --baseline tests/baselines/before_architecture_refactor.json
python3 tests/regression_tester.py check --build --stress
```