### PR TITLE
refactor: split request inspection stages

### DIFF
--- a/src/RequestInspector.cpp
+++ b/src/RequestInspector.cpp
@@ -128,6 +128,110 @@ static InspectRequestStatus toInspectStatus(RequestLineStatus status)
 	return (BAD_REQUEST);
 }
 
+static bool extractRequestLine(const std::string &rawRequest,
+	std::string &requestLine)
+{
+	std::stringstream ss;
+
+	ss << rawRequest;
+	if (!std::getline(ss, requestLine))
+		return (false);
+	return (true);
+}
+
+static InspectRequestStatus inspectHeaderSection(
+	const std::string &rawRequest,
+	RequestInspection &inspection,
+	std::string &headers)
+{
+	if (!HttpMessageUtils::findHeaderEnd(rawRequest, inspection.headerEnd,
+			inspection.bodyStart))
+		return (NEED_MORE_DATA);
+	if (inspection.headerEnd > MAX_HEADERS_SIZE)
+		return (HEADER_TOO_LARGE);
+	headers = rawRequest.substr(0, inspection.headerEnd);
+	return (COMPLETED);
+}
+
+static InspectRequestStatus inspectMessageFraming(
+	RequestInspection &inspection,
+	const std::string &headers)
+{
+	ContentLengthResult clResult;
+	TransferEncodingResult teResult;
+	size_t contentLength;
+	std::string version;
+
+	contentLength = 0;
+	clResult = getContentLength(headers, contentLength);
+	teResult = getTransferEncoding(headers);
+	version = inspection.requestLine.getVersion();
+	if (clResult == CL_INVALID)
+		return (BAD_REQUEST);
+	if (teResult == TE_INVALID)
+		return (BAD_REQUEST);
+	if (teResult == TE_UNSUPPORTED)
+		return (NOT_IMPLEMENTED);
+	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
+		return (BAD_REQUEST);
+	if (teResult == TE_CHUNKED && clResult == CL_VALID)
+		return (BAD_REQUEST);
+	if (clResult == CL_VALID)
+	{
+		inspection.hasContentLength = true;
+		inspection.contentLength = contentLength;
+	}
+	inspection.isChunked = (teResult == TE_CHUNKED);
+	return (COMPLETED);
+}
+
+static InspectRequestStatus inspectChunkedBody(
+	const std::string &rawRequest,
+	size_t maxBodySize,
+	RequestInspection &inspection)
+{
+	ChunkedDecodeStatus chunkedStatus;
+
+	chunkedStatus = ChunkedDecoder::inspect(rawRequest, inspection.bodyStart,
+		maxBodySize, inspection.messageEnd);
+	if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
+		return (NEED_MORE_DATA);
+	if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
+		return (REQUEST_TOO_LARGE);
+	if (chunkedStatus == CHUNKED_BAD_REQUEST)
+		return (BAD_REQUEST);
+	return (COMPLETED);
+}
+
+static InspectRequestStatus inspectContentLengthBody(
+	const std::string &rawRequest,
+	size_t maxBodySize,
+	RequestInspection &inspection)
+{
+	size_t currentBodySize;
+
+	if (inspection.contentLength > maxBodySize)
+		return (REQUEST_TOO_LARGE);
+	currentBodySize = rawRequest.length() - inspection.bodyStart;
+	if (currentBodySize < inspection.contentLength)
+		return (NEED_MORE_DATA);
+	inspection.messageEnd = inspection.bodyStart + inspection.contentLength;
+	return (COMPLETED);
+}
+
+static InspectRequestStatus inspectMessageBody(
+	const std::string &rawRequest,
+	size_t maxBodySize,
+	RequestInspection &inspection)
+{
+	if (inspection.isChunked)
+		return (inspectChunkedBody(rawRequest, maxBodySize, inspection));
+	if (inspection.hasContentLength)
+		return (inspectContentLengthBody(rawRequest, maxBodySize, inspection));
+	inspection.messageEnd = rawRequest.length();
+	return (COMPLETED);
+}
+
 void RequestInspector::inspectRequestLine(const std::string &requestLine, RequestLine &parsedLine)
 {
 	requestLineValid = false;
@@ -144,95 +248,27 @@ RequestInspection RequestInspector::inspectRequest(const std::string &rawRequest
 {
 	RequestInspection inspection;
 	std::string requestLine;
-	std::stringstream ss;
-	size_t contentLength;
-	size_t currentBodySize;
 	std::string headers;
-	std::string version;
-	TransferEncodingResult teResult;
-	ChunkedDecodeStatus chunkedStatus;
-	ContentLengthResult clResult;
+	InspectRequestStatus result;
 
 	if (rawRequest.empty())
 		return (finishInspection(*this, inspection, NEED_MORE_DATA));
 
-	ss << rawRequest;
-	if (!std::getline(ss, requestLine))
+	if (!extractRequestLine(rawRequest, requestLine))
 		return (finishInspection(*this, inspection, NEED_MORE_DATA));
 
 	inspectRequestLine(requestLine, inspection.requestLine);
 	if (this->status != COMPLETED)
 		return (finishInspection(*this, inspection, this->status));
 
-	if (!HttpMessageUtils::findHeaderEnd(rawRequest, inspection.headerEnd, inspection.bodyStart))
-		return (finishInspection(*this, inspection, NEED_MORE_DATA));
+	result = inspectHeaderSection(rawRequest, inspection, headers);
+	if (result != COMPLETED)
+		return (finishInspection(*this, inspection, result));
 
-	if (inspection.headerEnd > MAX_HEADERS_SIZE)
-		return (finishInspection(*this, inspection, HEADER_TOO_LARGE));
+	result = inspectMessageFraming(inspection, headers);
+	if (result != COMPLETED)
+		return (finishInspection(*this, inspection, result));
 
-	headers = rawRequest.substr(0, inspection.headerEnd);
-
-	contentLength = 0;
-	clResult = getContentLength(headers, contentLength);
-	teResult = getTransferEncoding(headers);
-	version = inspection.requestLine.getVersion();
-
-	if (clResult == CL_INVALID)
-		return (finishInspection(*this, inspection, BAD_REQUEST));
-
-	if (teResult == TE_INVALID)
-		return (finishInspection(*this, inspection, BAD_REQUEST));
-
-	if (teResult == TE_UNSUPPORTED)
-		return (finishInspection(*this, inspection, NOT_IMPLEMENTED));
-
-	if (version == "HTTP/1.0" && teResult != TE_ABSENT)
-		return (finishInspection(*this, inspection, BAD_REQUEST));
-
-	if (teResult == TE_CHUNKED && clResult == CL_VALID)
-		return (finishInspection(*this, inspection, BAD_REQUEST));
-
-	if (clResult == CL_VALID)
-	{
-		inspection.hasContentLength = true;
-		inspection.contentLength = contentLength;
-	}
-
-	inspection.isChunked = (teResult == TE_CHUNKED);
-
-	if (inspection.isChunked)
-	{
-		chunkedStatus = ChunkedDecoder::inspect(
-			rawRequest,
-			inspection.bodyStart,
-			maxBodySize,
-			inspection.messageEnd);
-
-		if (chunkedStatus == CHUNKED_NEED_MORE_DATA)
-			return (finishInspection(*this, inspection, NEED_MORE_DATA));
-
-		if (chunkedStatus == CHUNKED_BODY_TOO_LARGE)
-			return (finishInspection(*this, inspection, REQUEST_TOO_LARGE));
-
-		if (chunkedStatus == CHUNKED_BAD_REQUEST)
-			return (finishInspection(*this, inspection, BAD_REQUEST));
-
-		return (finishInspection(*this, inspection, COMPLETED));
-	}
-
-	if (inspection.hasContentLength)
-	{
-		if (inspection.contentLength > maxBodySize)
-			return (finishInspection(*this, inspection, REQUEST_TOO_LARGE));
-
-		currentBodySize = rawRequest.length() - inspection.bodyStart;
-		if (currentBodySize < inspection.contentLength)
-			return (finishInspection(*this, inspection, NEED_MORE_DATA));
-
-		inspection.messageEnd = inspection.bodyStart + inspection.contentLength;
-		return (finishInspection(*this, inspection, COMPLETED));
-	}
-
-	inspection.messageEnd = rawRequest.length();
-	return (finishInspection(*this, inspection, COMPLETED));
+	result = inspectMessageBody(rawRequest, maxBodySize, inspection);
+	return (finishInspection(*this, inspection, result));
 }


### PR DESCRIPTION
This pull request significantly refactors the `RequestInspector::inspectRequest` logic in `src/RequestInspector.cpp` to improve readability, modularity, and maintainability. The monolithic function is broken down into smaller, single-purpose static helper functions that each handle a distinct phase of HTTP request inspection. This makes the code easier to understand, test, and modify in the future.

Refactoring and modularization:

* Split the large `inspectRequest` function into several helper functions: `extractRequestLine`, `inspectHeaderSection`, `inspectMessageFraming`, `inspectChunkedBody`, `inspectContentLengthBody`, and `inspectMessageBody`, each handling a specific part of the request inspection process.
* Reordered and simplified control flow in `inspectRequest` to sequentially call these new helpers, immediately returning on error, which clarifies the inspection pipeline.

Code clarity and maintainability:

* Reduced code duplication and improved error handling by centralizing repeated logic (such as status checks and early returns) into the new helper functions.
* Retained the original `inspectRequestLine` implementation but moved it after the new helpers for logical grouping and readability.