### PR TITLE
Fix intermittent CGI 504 race

### DIFF
--- a/src/CgiEventHandler.cpp
+++ b/src/CgiEventHandler.cpp
@@ -4,6 +4,41 @@
 
 #include <sys/wait.h>
 
+namespace
+{
+	void	closeCgiStdin(Client &client, PollManager &pollManager,
+		CgiFdRegistry &fdRegistry)
+	{
+		fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
+		client.cgi.stdinFd = -1;
+		client.cgi.stdinClosed = true;
+	}
+
+	void	closeCgiStdout(Client &client, PollManager &pollManager,
+		CgiFdRegistry &fdRegistry)
+	{
+		fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
+		client.cgi.stdoutFd = -1;
+		client.cgi.stdoutClosed = true;
+	}
+
+	int	handleCgiFdError(int cgiFd, Client &client,
+		PollManager &pollManager, CgiFdRegistry &fdRegistry)
+	{
+		if (cgiFd == client.cgi.stdinFd)
+		{
+			closeCgiStdin(client, pollManager, fdRegistry);
+			return (1);
+		}
+		if (cgiFd == client.cgi.stdoutFd)
+		{
+			closeCgiStdout(client, pollManager, fdRegistry);
+			return (1);
+		}
+		return (0);
+	}
+}
+
 int	CgiEventHandler::handleEvent(int cgiFd, short revents,
 	std::map<int, Client> &clients,
 	const std::vector<ServerConfig> &configs, PollManager &pollManager,
@@ -24,22 +59,12 @@ int	CgiEventHandler::handleEvent(int cgiFd, short revents,
 	}
 
 	Client &client = clientIt->second;
-	if (revents & (POLLERR | POLLHUP | POLLNVAL))
+	if (revents & (POLLERR | POLLNVAL))
+		fdRemoved = handleCgiFdError(cgiFd, client, pollManager, fdRegistry);
+	if ((revents & POLLHUP) && cgiFd == client.cgi.stdinFd)
 	{
-		if (cgiFd == client.cgi.stdinFd)
-		{
-			fdRegistry.closeFd(client.cgi.stdinFd, pollManager);
-			client.cgi.stdinFd = -1;
-			client.cgi.stdinClosed = true;
-			fdRemoved = 1;
-		}
-		else if (cgiFd == client.cgi.stdoutFd)
-		{
-			fdRegistry.closeFd(client.cgi.stdoutFd, pollManager);
-			client.cgi.stdoutFd = -1;
-			client.cgi.stdoutClosed = true;
-			fdRemoved = 1;
-		}
+		closeCgiStdin(client, pollManager, fdRegistry);
+		fdRemoved = 1;
 	}
 	if ((revents & POLLOUT) && cgiFd == client.cgi.stdinFd)
 	{
@@ -52,7 +77,7 @@ int	CgiEventHandler::handleEvent(int cgiFd, short revents,
 		else if (client.cgi.stdinFd == -1)
 			fdRemoved = 1;
 	}
-	if ((revents & POLLIN) && cgiFd == client.cgi.stdoutFd)
+	if ((revents & (POLLIN | POLLHUP)) && cgiFd == client.cgi.stdoutFd)
 	{
 		if (readFromCgi(client, pollManager, fdRegistry) != 0)
 		{

--- a/src/CgiTimeoutHandler.cpp
+++ b/src/CgiTimeoutHandler.cpp
@@ -3,6 +3,31 @@
 
 #include <ctime>
 #include <iostream>
+#include <sys/wait.h>
+
+namespace
+{
+	static const int CGI_REAP_POLL_INTERVAL_MS = 100;
+
+	int	reapFinishedChild(Client &client)
+	{
+		int		status;
+		pid_t	result;
+
+		if (client.cgi.pid <= 0)
+			return (0);
+		result = waitpid(client.cgi.pid, &status, WNOHANG);
+		if (result == 0)
+			return (0);
+		if (result != client.cgi.pid)
+			return (1);
+		client.cgi.pid = -1;
+		client.cgi.finished = true;
+		if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+			return (0);
+		return (1);
+	}
+}
 
 int	CgiTimeoutHandler::getPollTimeoutMs(const std::map<int, Client> &clients)
 {
@@ -11,6 +36,7 @@ int	CgiTimeoutHandler::getPollTimeoutMs(const std::map<int, Client> &clients)
 	int shortestTimeout;
 	int elapsed;
 	int remaining;
+	int candidate;
 
 	shortestTimeout = -1;
 	now = std::time(NULL);
@@ -27,9 +53,12 @@ int	CgiTimeoutHandler::getPollTimeoutMs(const std::map<int, Client> &clients)
 
 			if (remaining <= 0)
 				return (0);
-
-			if (shortestTimeout == -1 || remaining * 1000 < shortestTimeout)
-				shortestTimeout = remaining * 1000;
+			candidate = remaining * 1000;
+			if (client.cgi.stdoutClosed
+				&& candidate > CGI_REAP_POLL_INTERVAL_MS)
+				candidate = CGI_REAP_POLL_INTERVAL_MS;
+			if (shortestTimeout == -1 || candidate < shortestTimeout)
+				shortestTimeout = candidate;
 		}
 		++it;
 	}
@@ -49,6 +78,19 @@ int	CgiTimeoutHandler::handleTimeouts(std::map<int, Client> &clients,
 	{
 		Client &client = it->second;
 
+		if (client.cgi.hasActiveProcess() && reapFinishedChild(client) != 0)
+		{
+			CgiCompletionHandler::fail(client, 502, "Bad Gateway",
+				configs, pollManager, fdRegistry);
+			++it;
+			continue;
+		}
+		if (client.cgi.stdoutClosed && client.cgi.finished)
+		{
+			CgiCompletionHandler::finish(client, pollManager);
+			++it;
+			continue;
+		}
 		if (isExpired(client, now))
 		{
 			std::cout << "CGI timeout for client fd " << client.fd << std::endl;


### PR DESCRIPTION
## Summary

Fixes the likely race behind #138 where a fast CGI process could incorrectly end as `504 Gateway Timeout` during parallel regression tests.

## Problem

When the CGI stdout pipe received `POLLHUP`, the event handler closed the stdout fd immediately. If `waitpid(..., WNOHANG)` returned `0` in the same iteration, the CGI session was left with:

- stdout already closed;
- no CGI fd left to wake the event loop;
- child pid still considered active.

In that state the server could wait until `CGI_TIMEOUT_SECONDS` and return `504`, even if the child exited normally shortly after.

## Changes

- Treat `POLLHUP` on CGI stdout as a readable EOF condition instead of closing stdout before `read()`.
- Keep CGI stdout draining logic centralized through `readFromCgi()`.
- Add periodic child reaping in `CgiTimeoutHandler` when stdout is already closed but the child process is not marked finished yet.
- Finish the CGI response from the timeout handler if the child exited successfully and stdout is closed.
- Return `502 Bad Gateway` if the child exits unsuccessfully during that reaping step.

## Validation

Not run in this environment. Please validate locally with:

```bash
make re
python3 tests/regression_tester.py compare \
    --build \
    --check-relink \
    --baseline tests/baselines/before_refactor.json
```

For confidence on #138, run the same command multiple times and also try:

```bash
python3 tests/regression_tester.py compare \
    --build \
    --check-relink \
    --stress \
    --baseline tests/baselines/before_refactor.json
```

Closes #138 if the repeated regression runs no longer produce intermittent `504` in the parallel CGI test.