### PR TITLE
fix: initialize Request valid flag

### DIFF
--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -1,7 +1,7 @@
 #include "Request.hpp"
 #include "utils.hpp"
 
-Request::Request() : isCgi(false)  {}
+Request::Request() : valid(false), isCgi(false) {}
 
 Request::~Request() {}
 


### PR DESCRIPTION
## Summary

- Initialize `Request::valid` to `false` in the constructor.
- Keep `Request::isCgi` initialized to `false` as before.

## Why

`Request::isValid()` returns the `valid` field, but this field was not initialized in `Request::Request()`. Before `setValid()` is called, reading it is undefined behavior and can randomly make a freshly constructed request appear valid.

## Notes

This is a minimal safety fix. It does not change parsing logic or request dispatch behavior except making the default request state deterministic.

## Tests

Not run here. Recommended local check:

```sh
make re
./tests/regression_tester.py --build --check-relink
```
