### PR TITLE
fix: use subject-allowed fcntl flags

### DIFF
--- a/src/CgiStartupHandler.cpp
+++ b/src/CgiStartupHandler.cpp
@@ -54,15 +54,7 @@ int	CgiStartupHandler::startForClient(Client &client,
 
 int	CgiStartupHandler::setNonBlockingFd(int fd)
 {
-	int flags;
-
-	flags = fcntl(fd, F_GETFL, 0);
-	if (flags == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+	if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
 	{
 		std::cerr << "fcntl: " << strerror(errno) << "\n";
 		return (1);

--- a/src/ListenerSocketHandler.cpp
+++ b/src/ListenerSocketHandler.cpp
@@ -35,15 +35,7 @@ ListenerSocketHandler &ListenerSocketHandler::operator=(
 
 int ListenerSocketHandler::setNonBlocking(int fd) const
 {
-	int flags;
-
-	flags = fcntl(fd, F_GETFL, 0);
-	if (flags == -1)
-	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
-		return (1);
-	}
-	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+	if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
 	{
 		std::cerr << "fcntl: " << strerror(errno) << "\n";
 		return (1);


### PR DESCRIPTION
## Summary

- remove `F_GETFL` usage from socket non-blocking setup
- remove `F_GETFL` usage from CGI pipe non-blocking setup
- keep `fcntl(fd, F_SETFL, O_NONBLOCK)` only, matching the subject restriction on allowed `fcntl` flags

## Scope

This PR intentionally changes only the `fcntl` usage issue. It does not refactor the event loop, CGI flow, or client lifecycle.

## Testing

Not run locally from this environment. The diff is intentionally minimal: two helper functions now call `fcntl` directly with `F_SETFL` and `O_NONBLOCK`.