### PR TITLE
Add configurable logger levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 NAME = webserv
 
 CXX = c++
+LOG_LEVEL ?= 1
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98 -g
+CXXFLAGS += -DWEBSERV_LOG_LEVEL=$(LOG_LEVEL)
 RM = rm -f
 
 SRC_DIR = src
 OBJ_DIR = obj
 INC_DIR = include
 
-SRC_FILES = main.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CookieParser.cpp SessionManager.cpp SessionHandler.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientEventHandler.cpp ClientResponseApplier.cpp ConnectionManager.cpp ClientTimeoutHandler.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp TemplateRenderer.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp MultipartParser.cpp UploadStorage.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp ListenerSocketHandler.cpp PollEventHandler.cpp
+SRC_FILES = main.cpp Logger.cpp WebServ.cpp RequestParser.cpp Request.cpp RequestHandler.cpp RequestInspector.cpp Response.cpp utils.cpp CookieParser.cpp SessionManager.cpp SessionHandler.cpp CgiCompletionHandler.cpp CgiHandler.cpp CgiFdRegistry.cpp CgiPipeIO.cpp CgiEventHandler.cpp CgiStartupHandler.cpp CgiTimeoutHandler.cpp Client.cpp ClientEventHandler.cpp ClientResponseApplier.cpp ConnectionManager.cpp ClientTimeoutHandler.cpp CgiSession.cpp CgiValidator.cpp ConfigLexer.cpp ConfigParser.cpp ConfigValidator.cpp HttpMethod.cpp MimeTypes.cpp StaticFileHandler.cpp ErrorResponseBuilder.cpp RedirectHandler.cpp CgiRequestHandler.cpp ErrorPageResolver.cpp ErrorResponseHandler.cpp PollManager.cpp CgiManager.cpp ChunkedDecoder.cpp UriUtils.cpp PathUtils.cpp TemplateRenderer.cpp Router.cpp RequestDispatcher.cpp StoragePathResolver.cpp MultipartParser.cpp UploadStorage.cpp UploadHandler.cpp DeleteHandler.cpp HttpMessageUtils.cpp RequestLine.cpp ListenerSocketHandler.cpp PollEventHandler.cpp
 
 SRCS = $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS = $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.cpp=.o))

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,0 +1,32 @@
+#ifndef LOGGER_HPP
+#define LOGGER_HPP
+
+#include <iostream>
+#include <streambuf>
+
+#ifndef WEBSERV_LOG_LEVEL
+#define WEBSERV_LOG_LEVEL 1
+#endif
+
+class NullBuffer : public std::streambuf
+{
+protected:
+	std::streambuf::int_type overflow(std::streambuf::int_type c);
+};
+
+class Logger
+{
+public:
+	static std::ostream	&error(void);
+	static std::ostream	&info(void);
+	static std::ostream	&debug(void);
+
+	static bool			isErrorEnabled(void);
+	static bool			isInfoEnabled(void);
+	static bool			isDebugEnabled(void);
+
+private:
+	static std::ostream	&nullStream(void);
+};
+
+#endif

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -1,5 +1,5 @@
 #include <CgiHandler.hpp>
-#include <iostream>
+#include "Logger.hpp"
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -80,14 +80,16 @@ static void debugPrintEnv(const std::string &title, const CgiEnv &env)
 {
 	CgiEnv::const_iterator it;
 
-	std::cout << "\n===== " << title << " =====" << std::endl;
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << "\n===== " << title << " =====" << std::endl;
 	it = env.begin();
 	while (it != env.end())
 	{
-		std::cout << it->first << "=" << it->second << std::endl;
+		Logger::debug() << it->first << "=" << it->second << std::endl;
 		it++;
 	}
-	std::cout << "===================================\n" << std::endl;
+	Logger::debug() << "===================================\n" << std::endl;
 }
 
 int CgiHandler::startCgi(const CgiContext &context, CgiProcess &process)
@@ -101,12 +103,12 @@ int CgiHandler::startCgi(const CgiContext &context, CgiProcess &process)
 
     if (pipe(stdinPipe) == -1)
     {
-        std::cerr << "pipe() failed: " << std::strerror(errno) << std::endl;
+        Logger::error() << "pipe() failed: " << std::strerror(errno) << std::endl;
         return (1);
     }
     if (pipe(stdoutPipe) == -1)
     {
-        std::cerr << "pipe() failed: " << std::strerror(errno) << std::endl;
+        Logger::error() << "pipe() failed: " << std::strerror(errno) << std::endl;
         close(stdinPipe[0]);
         close(stdinPipe[1]);
         return (1);
@@ -119,7 +121,7 @@ int CgiHandler::startCgi(const CgiContext &context, CgiProcess &process)
     pid = fork();
     if (pid == -1)
     {
-        std::cerr << "fork() failed: " << std::strerror(errno) << std::endl;
+        Logger::error() << "fork() failed: " << std::strerror(errno) << std::endl;
         close(stdinPipe[0]);
         close(stdinPipe[1]);
         close(stdoutPipe[0]);

--- a/src/CgiPipeIO.cpp
+++ b/src/CgiPipeIO.cpp
@@ -1,6 +1,6 @@
 #include "CgiPipeIO.hpp"
+#include "Logger.hpp"
 
-#include <iostream>
 #include <unistd.h>
 
 bool CgiPipeIO::hasInputFinished(const CgiSession &session)
@@ -18,7 +18,7 @@ int CgiPipeIO::writeToStdin(CgiSession &session)
 						 session.inputBuffer.c_str() + session.inputSent, remaining);
 	if (bytesWritten <= 0)
 	{
-		std::cerr << "Failed to write request body to CGI" << std::endl;
+		Logger::error() << "Failed to write request body to CGI" << std::endl;
 		return (1);
 	}
 	session.inputSent += static_cast<size_t>(bytesWritten);
@@ -33,7 +33,7 @@ CgiPipeIO::ReadResult CgiPipeIO::readFromStdout(CgiSession &session)
 	bytesRead = read(session.stdoutFd, buffer, sizeof(buffer));
 	if (bytesRead < 0)
 	{
-		std::cerr << "Failed to read CGI output" << std::endl;
+		Logger::error() << "Failed to read CGI output" << std::endl;
 		return (READ_ERROR);
 	}
 	if (bytesRead == 0)

--- a/src/CgiRequestHandler.cpp
+++ b/src/CgiRequestHandler.cpp
@@ -1,5 +1,6 @@
 #include "CgiRequestHandler.hpp"
 #include "CgiHandler.hpp"
+#include "Logger.hpp"
 #include "utils.hpp"
 #include "PathUtils.hpp"
 #include "UriUtils.hpp"
@@ -7,7 +8,6 @@
 #include <cctype>
 #include <ctime>
 #include <iomanip>
-#include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
@@ -339,6 +339,16 @@ static void addHttpHeaderVariables(CgiContext &context, const Request &request)
 	}
 }
 
+static void debugPrintCgiContext(const CgiContext &context)
+{
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << "CGI scriptPath: " << context.scriptPath << std::endl;
+	Logger::debug() << "CGI scriptFileName: " << context.scriptFileName << std::endl;
+	Logger::debug() << "CGI workingDirectory: " << context.workingDirectory << std::endl;
+	Logger::debug() << "Request body for CGI:\n[" << context.requestBody << "]\n";
+}
+
 static CgiContext buildCgiContext(const Request &request, const RouteConfig &route, const ServerConfig &server, const std::string &remoteAddr, const CgiResolvedPath &cgiPath)
 {
 	CgiContext context;
@@ -348,10 +358,7 @@ static CgiContext buildCgiContext(const Request &request, const RouteConfig &rou
 	context.scriptFileName = PathUtils::getFileName(cgiPath.scriptPath);
 	context.workingDirectory = PathUtils::getDirectoryName(cgiPath.scriptPath);
 	context.requestBody = request.getBody();
-	std::cout << "CGI scriptPath: " << context.scriptPath << std::endl;
-	std::cout << "CGI scriptFileName: " << context.scriptFileName << std::endl;
-	std::cout << "CGI workingDirectory: " << context.workingDirectory << std::endl;
-	std::cout << "Request body for CGI:\n[" << context.requestBody << "]\n";
+	debugPrintCgiContext(context);
 	addStandardCgiVariables(context, request, server, remoteAddr, cgiPath);
 	addHttpHeaderVariables(context, request);
 	addImplementationCgiVariables(context, request, route, cgiPath);

--- a/src/CgiStartupHandler.cpp
+++ b/src/CgiStartupHandler.cpp
@@ -2,12 +2,12 @@
 #include "CgiCompletionHandler.hpp"
 #include "CgiRequestHandler.hpp"
 #include "CgiValidator.hpp"
+#include "Logger.hpp"
 
 #include <cerrno>
 #include <ctime>
 #include <cstring>
 #include <fcntl.h>
-#include <iostream>
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -56,7 +56,7 @@ int	CgiStartupHandler::setNonBlockingFd(int fd)
 {
 	if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
 	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		Logger::error() << "fcntl: " << strerror(errno) << "\n";
 		return (1);
 	}
 	return (0);

--- a/src/CgiTimeoutHandler.cpp
+++ b/src/CgiTimeoutHandler.cpp
@@ -1,8 +1,8 @@
 #include "CgiTimeoutHandler.hpp"
 #include "CgiCompletionHandler.hpp"
+#include "Logger.hpp"
 
 #include <ctime>
-#include <iostream>
 #include <sys/wait.h>
 
 namespace
@@ -93,7 +93,8 @@ int	CgiTimeoutHandler::handleTimeouts(std::map<int, Client> &clients,
 		}
 		if (isExpired(client, now))
 		{
-			std::cout << "CGI timeout for client fd " << client.fd << std::endl;
+			Logger::info() << "CGI timeout for client fd " << client.fd
+				<< std::endl;
 			CgiCompletionHandler::fail(client, 504, "Gateway Timeout",
 				configs, pollManager, fdRegistry);
 		}

--- a/src/ClientEventHandler.cpp
+++ b/src/ClientEventHandler.cpp
@@ -1,11 +1,11 @@
 #include "ClientEventHandler.hpp"
 #include "ClientResponseApplier.hpp"
 #include "ErrorResponseHandler.hpp"
+#include "Logger.hpp"
 #include "RequestDispatcher.hpp"
 #include "RequestInspector.hpp"
 #include "RequestParser.hpp"
 #include "Response.hpp"
-#include <iostream>
 #include <poll.h>
 #include <string>
 #include <sys/socket.h>
@@ -28,13 +28,13 @@ namespace
 		bytesRead = recv(client.fd, buffer, sizeof(buffer), 0);
 		if (bytesRead < 0)
 		{
-			std::cerr << "Failed to read from client fd " << client.fd << std::endl;
+			Logger::error() << "Failed to read from client fd " << client.fd << std::endl;
 			client.state = CLOSING_CONNECTION;
 			return (1);
 		}
 		if (bytesRead == 0)
 		{
-			std::cout << "Client closed connection" << std::endl;
+			Logger::debug() << "Client closed connection" << std::endl;
 			client.state = CLOSING_CONNECTION;
 			return (0);
 		}
@@ -60,8 +60,8 @@ namespace
 		bytesRead = recv(client.fd, buffer, readSize, 0);
 		if (bytesRead < 0)
 		{
-			std::cerr << "Failed to discard request body from client fd "
-					  << client.fd << std::endl;
+			Logger::error() << "Failed to discard request body from client fd "
+							<< client.fd << std::endl;
 			client.state = CLOSING_CONNECTION;
 			return (1);
 		}
@@ -93,7 +93,7 @@ namespace
 		if (!client.responseReady)
 		{
 			dispatchResult = RequestDispatcher::dispatch(client, server,
-														 cgiManager, pollManager);
+												 cgiManager, pollManager);
 			if (dispatchResult == RequestDispatcher::DISPATCH_FAILED)
 				return (1);
 			if (dispatchResult == RequestDispatcher::ASYNC_STARTED)
@@ -109,8 +109,8 @@ namespace
 		bytesSent = send(client.fd, data, remaining, 0);
 		if (bytesSent <= 0)
 		{
-			std::cerr << "Failed to send response to client fd "
-					  << client.fd << std::endl;
+			Logger::error() << "Failed to send response to client fd "
+							<< client.fd << std::endl;
 			client.state = CLOSING_CONNECTION;
 			return (1);
 		}
@@ -137,7 +137,7 @@ namespace
 	}
 
 	void prepareInspectorErrorResponse(Client &client,
-									   const ServerConfig &server, InspectRequestStatus status)
+								   const ServerConfig &server, InspectRequestStatus status)
 	{
 		Response response;
 		int statusCode;
@@ -168,7 +168,7 @@ namespace
 	}
 
 	ClientEventHandler::Result handleDiscardingBody(Client &client,
-													short revents, PollManager &pollManager)
+											short revents, PollManager &pollManager)
 	{
 		if (revents & POLLIN)
 		{
@@ -182,7 +182,7 @@ namespace
 	}
 
 	ClientEventHandler::Result handleActiveCgiClient(Client &client,
-													 short revents)
+											 short revents)
 	{
 		if (revents & POLLIN)
 		{
@@ -195,7 +195,7 @@ namespace
 	}
 
 	ReadEventResult inspectClientRequest(Client &client,
-										 const ServerConfig &server, PollManager &pollManager)
+									 const ServerConfig &server, PollManager &pollManager)
 	{
 		RequestParser parser;
 		RequestInspector inspector;
@@ -222,7 +222,7 @@ namespace
 	}
 
 	ReadEventResult handleReadEvent(Client &client,
-									const ServerConfig &server, PollManager &pollManager)
+								const ServerConfig &server, PollManager &pollManager)
 	{
 		client.state = READING;
 		readFromClient(client);
@@ -232,8 +232,8 @@ namespace
 	}
 
 	ClientEventHandler::Result handleWriteEvent(Client &client,
-												const ServerConfig &server, CgiManager &cgiManager,
-												PollManager &pollManager)
+										const ServerConfig &server, CgiManager &cgiManager,
+										PollManager &pollManager)
 	{
 		client.state = WRITING;
 		sendToClient(client, server, cgiManager, pollManager);
@@ -244,8 +244,8 @@ namespace
 }
 
 ClientEventHandler::Result ClientEventHandler::handle(Client &client,
-													  short revents, const ServerConfig &server, CgiManager &cgiManager,
-													  PollManager &pollManager)
+											  short revents, const ServerConfig &server, CgiManager &cgiManager,
+											  PollManager &pollManager)
 {
 	ReadEventResult readResult;
 

--- a/src/ClientTimeoutHandler.cpp
+++ b/src/ClientTimeoutHandler.cpp
@@ -1,4 +1,5 @@
 #include "ClientTimeoutHandler.hpp"
+#include "Logger.hpp"
 
 #include <iostream>
 
@@ -42,7 +43,7 @@ int ClientTimeoutHandler::getPollTimeoutMs(const std::map<int, Client> &clients,
 }
 
 void ClientTimeoutHandler::collectExpiredClients(const std::map<int, Client> &clients,
-												 const std::vector<ServerConfig> &configs, std::vector<int> &expiredFds)
+											 const std::vector<ServerConfig> &configs, std::vector<int> &expiredFds)
 {
 	std::map<int, Client>::const_iterator it;
 	time_t now;
@@ -56,8 +57,8 @@ void ClientTimeoutHandler::collectExpiredClients(const std::map<int, Client> &cl
 		timeoutSeconds = getTimeoutSeconds(client, configs);
 		if (isExpired(client, now, timeoutSeconds))
 		{
-			std::cout << "Client timeout for fd " << client.fd << " after "
-					  << timeoutSeconds << "s of inactivity" << std::endl;
+			Logger::debug() << "Client timeout for fd " << client.fd << " after "
+							  << timeoutSeconds << "s of inactivity" << std::endl;
 			expiredFds.push_back(client.fd);
 		}
 		++it;

--- a/src/ConfigLexer.cpp
+++ b/src/ConfigLexer.cpp
@@ -1,7 +1,6 @@
 #include "ConfigLexer.hpp"
 #include "ConfigDebug.hpp"
-
-#include <iostream>
+#include "Logger.hpp"
 
 ConfigLexer::ConfigLexer(const std::string &input)
 	: inputText(input), position(0), currentLine(1), currentColumn(1) {}
@@ -116,15 +115,17 @@ static const char *tokenTypeToString(ConfigTokenType tokenType)
 
 void ConfigLexer::debugPrintTokens(const std::vector<ConfigToken> &tokens)
 {
-	std::cout << ConfigDebug::lexer << "[lexer] tokens" << ConfigDebug::reset << "\n";
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << ConfigDebug::lexer << "[lexer] tokens" << ConfigDebug::reset << "\n";
 	for (size_t index = 0; index < tokens.size(); ++index)
 	{
 		const ConfigToken &token = tokens[index];
-		std::cout << ConfigDebug::lexer
+		Logger::debug() << ConfigDebug::lexer
 			<< "  - " << tokenTypeToString(token.type)
 			<< " @ " << token.line << ":" << token.column;
 		if (!token.value.empty())
-			std::cout << " => '" << token.value << "'";
-		std::cout << ConfigDebug::reset << "\n";
+			Logger::debug() << " => '" << token.value << "'";
+		Logger::debug() << ConfigDebug::reset << "\n";
 	}
 }

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -1,10 +1,10 @@
 #include "ConfigParser.hpp"
 #include "ConfigValidator.hpp"
 #include "ConfigDebug.hpp"
+#include "Logger.hpp"
 
 #include <cstdlib>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
@@ -339,38 +339,41 @@ static std::string methodListToString(const std::set<HttpMethod> &methods)
 static void printRouteConfig(const RouteConfig &route, size_t indentLevel)
 {
 	std::string indent(indentLevel * 2, ' ');
-	std::cout << indent << "location " << route.path << "\n";
-	std::cout << indent << "  methods: " << methodListToString(route.methods) << "\n";
-	std::cout << indent << "  root: " << route.root << "\n";
-	std::cout << indent << "  index: " << route.index << "\n";
-	std::cout << indent << "  autoindex: " << (route.autoindex ? "on" : "off") << "\n";
-	std::cout << indent << "  upload_enable: " << (route.uploadEnable ? "on" : "off") << "\n";
+	Logger::debug() << indent << "location " << route.path << "\n";
+	Logger::debug() << indent << "  methods: " << methodListToString(route.methods) << "\n";
+	Logger::debug() << indent << "  root: " << route.root << "\n";
+	Logger::debug() << indent << "  index: " << route.index << "\n";
+	Logger::debug() << indent << "  autoindex: " << (route.autoindex ? "on" : "off") << "\n";
+	Logger::debug() << indent << "  upload_enable: " << (route.uploadEnable ? "on" : "off") << "\n";
 	if (!route.uploadStore.empty())
-		std::cout << indent << "  upload_store: " << route.uploadStore << "\n";
-	std::cout << indent << "  session_enable: " << (route.sessionEnable ? "on" : "off") << "\n";
+		Logger::debug() << indent << "  upload_store: " << route.uploadStore << "\n";
+	Logger::debug() << indent << "  session_enable: " << (route.sessionEnable ? "on" : "off") << "\n";
 	if (!route.sessionPath.empty())
-		std::cout << indent << "  session_path: " << route.sessionPath << "\n";
+		Logger::debug() << indent << "  session_path: " << route.sessionPath << "\n";
 	if (route.hasReturn)
-		std::cout << indent << "  return: " << route.returnCode << " " << route.returnPath << "\n";
+		Logger::debug() << indent << "  return: " << route.returnCode << " " << route.returnPath << "\n";
 	for (size_t cgiIndex = 0; cgiIndex < route.cgi.size(); ++cgiIndex)
-		std::cout << indent << "  cgi: " << route.cgi[cgiIndex].extension << " -> " << route.cgi[cgiIndex].executable << "\n";
+		Logger::debug() << indent << "  cgi: " << route.cgi[cgiIndex].extension
+			<< " -> " << route.cgi[cgiIndex].executable << "\n";
 }
 
 void ConfigParser::debugPrintConfig(const Config &config)
 {
-	std::cout << ConfigDebug::parser << "[parser] config tree" << ConfigDebug::reset << "\n";
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << ConfigDebug::parser << "[parser] config tree" << ConfigDebug::reset << "\n";
 	for (size_t serverIndex = 0; serverIndex < config.servers.size(); ++serverIndex)
 	{
 		const ServerConfig &server = config.servers[serverIndex];
-		std::cout << ConfigDebug::parser << "server #" << serverIndex << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  listen: " << server.listen.host << ":" << server.listen.port << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  server_name: " << server.serverName << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  root: " << server.root << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  index: " << server.index << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  client_max_body_size: " << server.clientMaxBodySize << ConfigDebug::reset << "\n";
-		std::cout << ConfigDebug::parser << "  client_timeout: " << server.clientTimeout << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "server #" << serverIndex << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  listen: " << server.listen.host << ":" << server.listen.port << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  server_name: " << server.serverName << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  root: " << server.root << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  index: " << server.index << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  client_max_body_size: " << server.clientMaxBodySize << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::parser << "  client_timeout: " << server.clientTimeout << ConfigDebug::reset << "\n";
 		for (std::map<int, std::string>::const_iterator errorPageIt = server.errorPages.begin(); errorPageIt != server.errorPages.end(); ++errorPageIt)
-			std::cout << ConfigDebug::parser << "  error_page " << errorPageIt->first << " => " << errorPageIt->second << ConfigDebug::reset << "\n";
+			Logger::debug() << ConfigDebug::parser << "  error_page " << errorPageIt->first << " => " << errorPageIt->second << ConfigDebug::reset << "\n";
 		for (size_t routeIndex = 0; routeIndex < server.routes.size(); ++routeIndex)
 			printRouteConfig(server.routes[routeIndex], 2);
 	}

--- a/src/ConfigValidator.cpp
+++ b/src/ConfigValidator.cpp
@@ -1,8 +1,8 @@
 #include "ConfigValidator.hpp"
 #include "ConfigDebug.hpp"
+#include "Logger.hpp"
 
 #include <cctype>
-#include <iostream>
 #include <map>
 #include <set>
 #include <sstream>
@@ -289,16 +289,18 @@ void ConfigValidator::validate(const Config &config)
 
 void ConfigValidator::debugPrintValidation(const Config &config)
 {
-	std::cout << ConfigDebug::validator << "[validator] config is valid"
-			  << ConfigDebug::reset << "\n";
-	std::cout << ConfigDebug::validator << "  servers: "
-			  << config.servers.size() << ConfigDebug::reset << "\n";
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << ConfigDebug::validator << "[validator] config is valid"
+					<< ConfigDebug::reset << "\n";
+	Logger::debug() << ConfigDebug::validator << "  servers: "
+					<< config.servers.size() << ConfigDebug::reset << "\n";
 	for (size_t serverIndex = 0; serverIndex < config.servers.size(); ++serverIndex)
 	{
 		const ServerConfig &server = config.servers[serverIndex];
 
-		std::cout << ConfigDebug::validator << "  server #"
-				  << serverIndex << " routes: " << server.routes.size()
-				  << ConfigDebug::reset << "\n";
+		Logger::debug() << ConfigDebug::validator << "  server #"
+						<< serverIndex << " routes: " << server.routes.size()
+						<< ConfigDebug::reset << "\n";
 	}
 }

--- a/src/ListenerSocketHandler.cpp
+++ b/src/ListenerSocketHandler.cpp
@@ -1,8 +1,8 @@
 #include "ListenerSocketHandler.hpp"
+#include "Logger.hpp"
 #include <cerrno>
 #include <cstring>
 #include <fcntl.h>
-#include <iostream>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
@@ -37,7 +37,7 @@ int ListenerSocketHandler::setNonBlocking(int fd) const
 {
 	if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
 	{
-		std::cerr << "fcntl: " << strerror(errno) << "\n";
+		Logger::error() << "fcntl: " << strerror(errno) << "\n";
 		return (1);
 	}
 	return (0);
@@ -51,15 +51,15 @@ int ListenerSocketHandler::initListeningSocket(void) const
 	listeningSocket = socket(AF_INET, SOCK_STREAM, 0);
 	if (listeningSocket == -1)
 	{
-		std::cerr << "socket() failed: " << std::strerror(errno) << "\n";
+		Logger::error() << "socket() failed: " << std::strerror(errno) << "\n";
 		return (-1);
 	}
-	std::cout << "Server socked created, FD = " << listeningSocket << "\n";
+	Logger::debug() << "Server socked created, FD = " << listeningSocket << "\n";
 	opt = 1;
 	if (setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR,
 			&opt, sizeof(opt)) == -1)
 	{
-		std::cerr << "setsockopt() failed: " << std::strerror(errno) << "\n";
+		Logger::error() << "setsockopt() failed: " << std::strerror(errno) << "\n";
 		close(listeningSocket);
 		return (-1);
 	}
@@ -89,13 +89,13 @@ int ListenerSocketHandler::bindSockAddress(int listeningSocket,
 	ret = getaddrinfo(hostCstr, portStr.c_str(), &hints, &res);
 	if (ret)
 	{
-		std::cerr << "getaddrinfo: " << gai_strerror(ret) << "\n";
+		Logger::error() << "getaddrinfo: " << gai_strerror(ret) << "\n";
 		close(listeningSocket);
 		return (1);
 	}
 	if (bind(listeningSocket, res->ai_addr, res->ai_addrlen) == -1)
 	{
-		std::cerr << "Error binding socket\n" << std::strerror(errno) << "\n";
+		Logger::error() << "Error binding socket\n" << std::strerror(errno) << "\n";
 		freeaddrinfo(res);
 		close(listeningSocket);
 		return (1);
@@ -116,20 +116,20 @@ int ListenerSocketHandler::setupSingleListener(const ServerConfig &config,
 		return (1);
 	if (listen(listeningSocket, 10) == -1)
 	{
-		std::cerr << "Error on socket " << configIndex << " listening\n";
+		Logger::error() << "Error on socket " << configIndex << " listening\n";
 		close(listeningSocket);
 		return (1);
 	}
 	if (setNonBlocking(listeningSocket))
 	{
-		std::cerr << "Error setting socket " << configIndex
+		Logger::error() << "Error setting socket " << configIndex
 			<< " as Non blocking\n";
 		close(listeningSocket);
 		return (1);
 	}
 	listenerFdToIndex[listeningSocket] = configIndex;
 	pollManager.addFd(listeningSocket, POLLIN);
-	std::cout << "Listening on " << config.listen.host << ":"
+	Logger::info() << "Listening on " << config.listen.host << ":"
 		<< config.listen.port << "\n";
 	return (0);
 }
@@ -145,7 +145,7 @@ int ListenerSocketHandler::setup(const std::vector<ServerConfig> &configs,
 	while (i < configs.size())
 	{
 		if (setupSingleListener(configs[i], i, pollManager))
-			std::cerr << "Server Block " << i << " setup failed!\n";
+			Logger::error() << "Server Block " << i << " setup failed!\n";
 		else
 			stop = false;
 		++i;
@@ -180,12 +180,12 @@ int ListenerSocketHandler::acceptConnection(int listeningSocket,
 	if (clientSocket == -1)
 	{
 		if (errno != EAGAIN && errno != EWOULDBLOCK)
-			std::cerr << "accept: " << strerror(errno) << std::endl;
+			Logger::error() << "accept: " << strerror(errno) << std::endl;
 		return (-1);
 	}
 	if (setNonBlocking(clientSocket))
 	{
-		std::cerr << "fcntl: " << strerror(errno) << std::endl;
+		Logger::error() << "fcntl: " << strerror(errno) << std::endl;
 		close(clientSocket);
 		return (-1);
 	}

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,50 @@
+#include "Logger.hpp"
+
+std::streambuf::int_type	NullBuffer::overflow(std::streambuf::int_type c)
+{
+	return (traits_type::not_eof(c));
+}
+
+std::ostream	&Logger::nullStream(void)
+{
+	static NullBuffer	buffer;
+	static std::ostream	stream(&buffer);
+
+	return (stream);
+}
+
+bool	Logger::isErrorEnabled(void)
+{
+	return (WEBSERV_LOG_LEVEL >= 1);
+}
+
+bool	Logger::isInfoEnabled(void)
+{
+	return (WEBSERV_LOG_LEVEL >= 2);
+}
+
+bool	Logger::isDebugEnabled(void)
+{
+	return (WEBSERV_LOG_LEVEL >= 3);
+}
+
+std::ostream	&Logger::error(void)
+{
+	if (isErrorEnabled())
+		return (std::cerr);
+	return (nullStream());
+}
+
+std::ostream	&Logger::info(void)
+{
+	if (isInfoEnabled())
+		return (std::cout);
+	return (nullStream());
+}
+
+std::ostream	&Logger::debug(void)
+{
+	if (isDebugEnabled())
+		return (std::cout);
+	return (nullStream());
+}

--- a/src/PollEventHandler.cpp
+++ b/src/PollEventHandler.cpp
@@ -1,6 +1,6 @@
 #include "PollEventHandler.hpp"
 #include "ClientEventHandler.hpp"
-#include <iostream>
+#include "Logger.hpp"
 #include <unistd.h>
 
 namespace
@@ -16,8 +16,8 @@ namespace
 		{
 			if (clientIt->second.cgi.isActive())
 			{
-				std::cout << "Cleaning CGI for disconnected client fd "
-						  << fd << std::endl;
+				Logger::debug() << "Cleaning CGI for disconnected client fd "
+							  << fd << std::endl;
 				cgiManager.cleanup(clientIt->second, pollManager);
 			}
 			clients.erase(clientIt);
@@ -33,9 +33,9 @@ namespace
 	}
 
 	PollEventHandler::Result handleCgiFd(const pollfd &pollFd,
-										 std::map<int, Client> &clients,
-										 const std::vector<ServerConfig> &configs,
-										 CgiManager &cgiManager, PollManager &pollManager)
+									 std::map<int, Client> &clients,
+									 const std::vector<ServerConfig> &configs,
+									 CgiManager &cgiManager, PollManager &pollManager)
 	{
 		if (cgiManager.handleEvent(pollFd.fd, pollFd.revents, clients,
 								   configs, pollManager) == 0)
@@ -44,8 +44,8 @@ namespace
 	}
 
 	PollEventHandler::Result handleListenerFd(const pollfd &pollFd,
-											  std::map<int, Client> &clients,
-											  ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
+									  std::map<int, Client> &clients,
+									  ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
 	{
 		if (pollFd.revents & POLLIN)
 			listenerSocketHandler.acceptConnection(pollFd.fd, clients, pollManager);
@@ -53,9 +53,9 @@ namespace
 	}
 
 	PollEventHandler::Result handleClientFd(const pollfd &pollFd,
-											std::map<int, Client> &clients,
-											const std::vector<ServerConfig> &configs, CgiManager &cgiManager,
-											ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
+									std::map<int, Client> &clients,
+									const std::vector<ServerConfig> &configs, CgiManager &cgiManager,
+									ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
 	{
 		std::map<int, Client>::iterator clientIt;
 		ClientEventHandler::Result result;
@@ -76,9 +76,9 @@ namespace
 }
 
 PollEventHandler::Result PollEventHandler::handle(const pollfd &pollFd,
-												  std::map<int, Client> &clients,
-												  const std::vector<ServerConfig> &configs, CgiManager &cgiManager,
-												  ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
+										  std::map<int, Client> &clients,
+										  const std::vector<ServerConfig> &configs, CgiManager &cgiManager,
+										  ListenerSocketHandler &listenerSocketHandler, PollManager &pollManager)
 {
 	if (cgiManager.isCgiFd(pollFd.fd))
 		return (handleCgiFd(pollFd, clients, configs, cgiManager, pollManager));

--- a/src/RequestDispatcher.cpp
+++ b/src/RequestDispatcher.cpp
@@ -2,10 +2,9 @@
 
 #include "CgiRequestHandler.hpp"
 #include "HttpMethod.hpp"
+#include "Logger.hpp"
 #include "RequestHandler.hpp"
 #include "Router.hpp"
-
-#include <iostream>
 
 static bool shouldHandleBeforeCgi(const Client &client, const RouteConfig &route,
 								  const ServerConfig &server)
@@ -23,11 +22,11 @@ static bool shouldHandleBeforeCgi(const Client &client, const RouteConfig &route
 }
 
 RequestDispatcher::Result RequestDispatcher::dispatch(Client &client, const ServerConfig &server,
-											  CgiManager &cgiManager, PollManager &pollManager)
+										  CgiManager &cgiManager, PollManager &pollManager)
 {
 	const RouteConfig &route = Router::resolve(server, client.getRequest().getPath());
 
-	std::cout << "Matched route: " << route.path << std::endl;
+	Logger::debug() << "Matched route: " << route.path << std::endl;
 
 	if (CgiRequestHandler::isCgiRequest(client.getRequest(), route))
 	{
@@ -44,8 +43,8 @@ RequestDispatcher::Result RequestDispatcher::dispatch(Client &client, const Serv
 
 	Response response = RequestHandler::handleRequest(client.getRequest(), route, server);
 	prepareResponse(client, response);
-	std::cout << "Response to client:\n\n"
-			  << client.responseBuffer << std::endl;
+	Logger::debug() << "Response ready, size = "
+				<< client.responseBuffer.size() << " bytes" << std::endl;
 
 	return (RESPONSE_READY);
 }

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -21,6 +21,25 @@ static void parseHeader(std::string &header, Request &request)
 	request.addHeader(key, value);
 }
 
+static void debugPrintParsedRequest(const Request &request)
+{
+	std::map<std::string, std::string>::const_iterator it;
+
+	if (!Logger::isDebugEnabled())
+		return;
+	Logger::debug() << "Parsed method: " << request.getMethod() << std::endl;
+	Logger::debug() << "Parsed path: " << request.getPath() << std::endl;
+	Logger::debug() << "Parsed version: " << request.getVersion() << std::endl;
+	Logger::debug() << "Parsed body: [" << request.getBody() << "]" << std::endl;
+	Logger::debug() << "Parsed headers:" << std::endl;
+	it = request.getHeaders().begin();
+	while (it != request.getHeaders().end())
+	{
+		Logger::debug() << it->first << " = [" << it->second << "]" << std::endl;
+		++it;
+	}
+}
+
 int RequestParser::parse(const std::string &rawRequest, Request &req, const RequestInspection &inspection)
 {
 	std::string headerPart;
@@ -66,20 +85,7 @@ int RequestParser::parse(const std::string &rawRequest, Request &req, const Requ
 	}
 
 	req.setBody(body);
-
-	if (Logger::isDebugEnabled())
-	{
-		Logger::debug() << "Parsed method: " << req.getMethod() << std::endl;
-		Logger::debug() << "Parsed path: " << req.getPath() << std::endl;
-		Logger::debug() << "Parsed version: " << req.getVersion() << std::endl;
-		Logger::debug() << "Parsed body: [" << req.getBody() << "]" << std::endl;
-		Logger::debug() << "Parsed headers:" << std::endl;
-		for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
-			 it != req.getHeaders().end(); ++it)
-		{
-			Logger::debug() << it->first << " = [" << it->second << "]" << std::endl;
-		}
-	}
+	debugPrintParsedRequest(req);
 
 	if (req.getMethod().empty())
 	{

--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -1,11 +1,11 @@
 #include "RequestParser.hpp"
 #include "ChunkedDecoder.hpp"
 #include "HttpMessageUtils.hpp"
+#include "Logger.hpp"
 #include "Request.hpp"
 
 #include <sstream>
 #include <string>
-#include <iostream>
 #include <map>
 
 static void parseHeader(std::string &header, Request &request)
@@ -67,21 +67,23 @@ int RequestParser::parse(const std::string &rawRequest, Request &req, const Requ
 
 	req.setBody(body);
 
-	std::cout << "Parsed method: " << req.getMethod() << std::endl;
-	std::cout << "Parsed path: " << req.getPath() << std::endl;
-	std::cout << "Parsed version: " << req.getVersion() << std::endl;
-	std::cout << "Parsed body: [" << req.getBody() << "]" << std::endl;
-
-	std::cout << "Parsed headers:" << std::endl;
-	for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
-		 it != req.getHeaders().end(); ++it)
+	if (Logger::isDebugEnabled())
 	{
-		std::cout << it->first << " = [" << it->second << "]" << std::endl;
+		Logger::debug() << "Parsed method: " << req.getMethod() << std::endl;
+		Logger::debug() << "Parsed path: " << req.getPath() << std::endl;
+		Logger::debug() << "Parsed version: " << req.getVersion() << std::endl;
+		Logger::debug() << "Parsed body: [" << req.getBody() << "]" << std::endl;
+		Logger::debug() << "Parsed headers:" << std::endl;
+		for (std::map<std::string, std::string>::const_iterator it = req.getHeaders().begin();
+			 it != req.getHeaders().end(); ++it)
+		{
+			Logger::debug() << it->first << " = [" << it->second << "]" << std::endl;
+		}
 	}
 
 	if (req.getMethod().empty())
 	{
-		std::cout << "Failed to parse request\n";
+		Logger::debug() << "Failed to parse request\n";
 		return (1);
 	}
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -1,10 +1,10 @@
 #include "Response.hpp"
 
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <sstream>
 
+#include "Logger.hpp"
 #include "utils.hpp"
 
 Response::Response () : statusCode(0) {}
@@ -92,7 +92,7 @@ void Response::setBodyFromFile (const std::string &path)
 
 	if (!file)
 	{
-		std::cerr << "File not found!\n";
+		Logger::error() << "File not found: " << path << "\n";
 	}
 	std::ostringstream ss;
 	ss << file.rdbuf ();

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -1,37 +1,37 @@
 #include "WebServ.hpp"
+#include "Logger.hpp"
 #include "PollEventHandler.hpp"
 #include <cerrno>
 #include <cstring>
-#include <iostream>
 #include <poll.h>
 #include <vector>
 
 WebServ::WebServ()
 {
-	std::cout << "WebServ created!\n";
+	Logger::debug() << "WebServ created!\n";
 }
 
 WebServ::WebServ(const WebServ &other)
 {
 	(void)other;
-	std::cout << "WebServ copy constructor called!\n";
+	Logger::debug() << "WebServ copy constructor called!\n";
 }
 
 WebServ::~WebServ()
 {
-	std::cout << "WebServ destroyed!\n";
+	Logger::debug() << "WebServ destroyed!\n";
 }
 
 WebServ &WebServ::operator=(const WebServ &other)
 {
 	(void)other;
-	std::cout << "WebServ assignement operator called!\n";
+	Logger::debug() << "WebServ assignement operator called!\n";
 	return (*this);
 }
 
 int WebServ::setup(std::vector<ServerConfig> servers)
 {
-	std::cout << "WebServ setup called!\n";
+	Logger::debug() << "WebServ setup called!\n";
 	configs = servers;
 	return (listenerSocketHandler.setup(configs, pollManager));
 }
@@ -51,7 +51,7 @@ static int combinePollTimeoutMs(int first, int second)
 
 int WebServ::run()
 {
-	std::cout << "WebServ run called!\n";
+	Logger::debug() << "WebServ run called!\n";
 
 	while (true)
 	{
@@ -74,15 +74,14 @@ int WebServ::run()
 		{
 			if (errno == EINTR)
 				continue;
-			std::cerr << "poll: " << strerror(errno) << std::endl;
+			Logger::error() << "poll: " << strerror(errno) << std::endl;
 			return (1);
 		}
 		cgiManager.checkTimeouts(connectionManager.getClients(), configs, pollManager);
 		connectionManager.enforceTimeouts(configs, cgiManager, listenerSocketHandler, pollManager);
 		if (ready == 0)
 			continue;
-		std::cout << "Sockets Ready - " << ready << "\n"
-				  << std::endl;
+		Logger::debug() << "Sockets Ready - " << ready << "\n" << std::endl;
 		size_t i = 0;
 		while (i < pollFds.size())
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,15 @@
 #include "ConfigParser.hpp"
+#include "Logger.hpp"
 #include "WebServ.hpp"
 
 #include <exception>
-#include <iostream>
 #include <signal.h>
 
 static int	setupSignals()
 {
 	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
 	{
-		std::cerr << "Failed to ignore SIGPIPE" << std::endl;
+		Logger::error() << "Failed to ignore SIGPIPE" << std::endl;
 		return (1);
 	}
 	return (0);
@@ -34,19 +34,19 @@ int	main(int argc, char **argv)
 	}
 	catch (const std::exception &e)
 	{
-		std::cerr << e.what() << std::endl;
+		Logger::error() << e.what() << std::endl;
 		return (1);
 	}
 
 	if (config.servers.empty())
 	{
-		std::cerr << "No server blocks found in config" << std::endl;
+		Logger::error() << "No server blocks found in config" << std::endl;
 		return (1);
 	}
 
 	if (serv.setup(config.servers) != 0)
 	{
-		std::cerr << "All server blocks failed, error setting up WebServ!" << std::endl;
+		Logger::error() << "All server blocks failed, error setting up WebServ!" << std::endl;
 		return (1);
 	}
 	return (serv.run());


### PR DESCRIPTION
Summary:
- Add C++98 Logger with error, info and debug streams.
- Add Makefile LOG_LEVEL support.
- Start replacing direct output in WebServ and ListenerSocketHandler.

Usage:
make re
make re LOG_LEVEL=2
make re LOG_LEVEL=3

Note: use make re when switching levels because the level is passed through compiler flags.