### PR TITLE
Agent/custom makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,33 @@ RM := rm -rf
 
 LOG_LEVEL ?= 1
 
+ifeq ($(LOG_LEVEL),1)
+LOG_LEVEL_DESC := errors only
+else ifeq ($(LOG_LEVEL),2)
+LOG_LEVEL_DESC := errors + info
+else ifeq ($(LOG_LEVEL),3)
+LOG_LEVEL_DESC := errors + info + debug
+else
+LOG_LEVEL_DESC := custom
+endif
+
 CXXFLAGS := -Wall -Wextra -Werror -std=c++98 -g
 DEPFLAGS := -MMD -MP
 
 SRC_DIR := src
 OBJ_DIR := obj
 INC_DIR := include
+
+LOG_LEVEL_FILE := $(OBJ_DIR)/.log_level
+BUILD_MARKER := $(OBJ_DIR)/.build_started
+
+RESET := \033[0m
+BOLD := \033[1m
+RED := \033[31m
+GREEN := \033[32m
+YELLOW := \033[33m
+MAGENTA := \033[35m
+CYAN := \033[36m
 
 # -------------------------------
 # Include directories
@@ -140,23 +161,52 @@ DEPS := $(OBJS:.o=.d)
 #                                 Build Rules                                  #
 # **************************************************************************** #
 
-all: $(NAME)
+all:
+	@printf "\n$(BOLD)Webserv build$(RESET)\n"
+	@printf "$(CYAN)[CONFIG]$(RESET) Target: $(NAME)\n"
+	@printf "$(CYAN)[CONFIG]$(RESET) Logger level: $(LOG_LEVEL)"
+	@printf " ($(LOG_LEVEL_DESC))\n"
+	@printf "$(YELLOW)[CHECK]$(RESET) Resolving build dependencies\n"
+	@$(RM) $(BUILD_MARKER)
+	@$(MAKE) --no-print-directory $(NAME)
+	@$(RM) $(BUILD_MARKER)
+	@printf "$(GREEN)[DONE]$(RESET) $(BOLD)$(NAME)$(RESET) is ready\n"
+
+$(LOG_LEVEL_FILE): FORCE
+	@mkdir -p $(OBJ_DIR)
+	@if [ ! -f $@ ]; then \
+		printf "%s\n" "$(LOG_LEVEL)" > $@; \
+	elif [ "$$(cat $@)" != "$(LOG_LEVEL)" ]; then \
+		old_level="$$(cat $@)"; \
+		printf "$(MAGENTA)[CONFIG]$(RESET) "; \
+		printf "Logger level changed: %s -> $(LOG_LEVEL)\n" "$$old_level"; \
+		printf "%s\n" "$(LOG_LEVEL)" > $@; \
+	fi
 
 $(NAME): $(OBJS)
-	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
+	@printf "$(YELLOW)[LINK]$(RESET) Creating $(BOLD)$(NAME)$(RESET)\n"
+	@$(CXX) $(CXXFLAGS) $(OBJS) -o $@
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp Makefile $(LOG_LEVEL_FILE)
 	@mkdir -p $(@D)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
+	@if mkdir $(BUILD_MARKER) 2>/dev/null; then \
+		printf "$(YELLOW)[BUILD]$(RESET) Compiling source files\n"; \
+	fi
+	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 clean:
-	$(RM) $(OBJ_DIR)
+	@printf "$(RED)[CLEAN]$(RESET) Removing object files\n"
+	@$(RM) $(OBJ_DIR)
 
 fclean: clean
-	$(RM) $(NAME)
+	@printf "$(RED)[FCLEAN]$(RESET) Removing $(NAME)\n"
+	@$(RM) $(NAME)
 
-re: fclean all
+re: fclean
+	@$(MAKE) --no-print-directory all LOG_LEVEL=$(LOG_LEVEL)
+
+FORCE:
 
 -include $(DEPS)
 
-.PHONY: all clean fclean re
+.PHONY: all clean fclean re FORCE

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ RM := rm -rf
 
 LOG_LEVEL ?= 1
 
+# -------------------------------
+# Log level description
+# -------------------------------
+
 ifeq ($(LOG_LEVEL),1)
 LOG_LEVEL_DESC := errors only
 else ifeq ($(LOG_LEVEL),2)
@@ -19,6 +23,10 @@ else
 LOG_LEVEL_DESC := custom
 endif
 
+# -------------------------------
+# Compiler flags
+# -------------------------------
+
 CXXFLAGS := -Wall -Wextra -Werror -std=c++98 -g
 DEPFLAGS := -MMD -MP
 
@@ -28,6 +36,10 @@ INC_DIR := include
 
 LOG_LEVEL_FILE := $(OBJ_DIR)/.log_level
 BUILD_MARKER := $(OBJ_DIR)/.build_started
+
+# -------------------------------
+# Color codes
+# -------------------------------
 
 RESET := \033[0m
 BOLD := \033[1m
@@ -162,7 +174,7 @@ DEPS := $(OBJS:.o=.d)
 # **************************************************************************** #
 
 all:
-	@printf "\n$(BOLD)Webserv build$(RESET)\n"
+	@printf "$(BOLD)Webserv build$(RESET)\n"
 	@printf "$(CYAN)[CONFIG]$(RESET) Target: $(NAME)\n"
 	@printf "$(CYAN)[CONFIG]$(RESET) Logger level: $(LOG_LEVEL)"
 	@printf " ($(LOG_LEVEL_DESC))\n"


### PR DESCRIPTION
This pull request significantly improves the `Makefile` by adding enhanced logging, colored and descriptive build output, and better handling of the logger level configuration. These changes make the build process more informative and user-friendly, helping developers understand the current build state and configuration at a glance.

**Build process improvements:**

* Added color-coded and descriptive output messages throughout the build steps, including configuration, dependency resolution, compilation, linking, and cleanup, to make the build process more transparent and user-friendly.
* Introduced variables for color codes and text formatting (e.g., `BOLD`, `RED`, `GREEN`, etc.) to support the enhanced output.

**Logger level handling:**

* Added logic to track and display the current logger level and its description, and to detect and notify when the logger level changes between builds, using a `.log_level` file in the object directory. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12-R51) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L143-R224)

**Build system robustness:**

* Improved dependency handling by adding a build marker (`.build_started`) and updating rules to ensure proper sequencing and atomicity of build steps.
* Refactored the `re` rule to ensure it cleans and rebuilds with the current logger level, and updated phony targets for clarity.